### PR TITLE
cli: install via pipenv w/o --pre

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -36,7 +36,7 @@ $ pip install invenio-cli
 Via pipenv:
 
 ``` console
-$ pipenv install --pre invenio-cli
+$ pipenv install invenio-cli
 ```
 
 Via pipx:


### PR DESCRIPTION
Installing with `pipenv install --pre`, install 1.0.0a9 which is **not** what we want.