### PR TITLE
global: separate commands and output and [more]

### DIFF
--- a/docs/develop/cleanup.md
+++ b/docs/develop/cleanup.md
@@ -1,12 +1,25 @@
 # Cleanup after you
 
+## Stop the instance
+
+We have reached the end of this journey, we are going to stop the instance. This will **NOT** destroy images, containers or volumes i.e. your data will be preserved.
+
+``` bash
+^C
+Stopping server and worker...
+Server and worker stopped...
+```
+
 ## Destroy the instance
 
-Finally, we want to destroy it. This will take us to a clean state. Note that it destroys images, containers and volumes (the ones defined in the `february-release-2/docker-compose.full.yml`. ).
+If you want to get to a clean state with no images, containers or volumes, then destroy the instance. This **WILL** permanently erase your volume data (database and Elasticsearch indices).
+It destroys the images, containers and volumes defined in the `february-release-2/docker-compose.full.yml`.
 
-Stop the application:
+After stopping the application per above, destroy it:
 
-``` console
-$ invenio-cli destroy
+``` bash
+invenio-cli destroy
+```
+```console
 TODO: Revisit destroy command...
 ```

--- a/docs/develop/customize.md
+++ b/docs/develop/customize.md
@@ -4,19 +4,26 @@ As we just saw, overriding configured values is an easy and common way of custom
 
 ## Update the logo
 
-We are going to change the logo, take an *svg* file and update your **local** static files (You can use the [invenio color logo](https://github.com/inveniosoftware/invenio-theme/blob/master/invenio_theme/static/images/invenio-color.svg)):
+We are going to change the logo. Take an *svg* file and copy it to your **local** static files. You can use the [invenio color logo](https://github.com/inveniosoftware/invenio-theme/raw/master/invenio_theme/static/images/invenio-color.svg):
 
-``` console
-$ cp ./path/to/new/color/logo.svg static/images/logo.svg
+``` bash
+cp ./path/to/new/color/logo.svg static/images/logo.svg
 ```
 
 Then, use the `update` command:
 
+``` bash
+invenio-cli update --no-install-js
+```
 ``` console
-$ invenio-cli update --no-install-js
+# Summarized output
 Collecting statics and assets...
+Collect static from blueprints.
+Created webpack project.
 Copying project statics and assets...
+Symlinking assets/...
 Building assets...
+Built webpack project.
 ```
 
 Passing the `--no-install-js` option, skips re-installation of JS dependencies.
@@ -26,20 +33,18 @@ Go to the browser [*https://localhost:5000/*](https://localhost:5000) or refresh
 !!! warning "That evil cache"
     If you do not see it changing, check in an incognito window; the browser might have cached the logo.
 
-Need further customizations? Have you thought of creating your own extensions? How to add them to your InvenioRDM instance is explained in the next section - [here](../extensions/custom.md).
-
 ## Change colors
 
 You might also be wondering: *How do I change the colors so I can make my instance look like my institution's theme?*
 
 We are going to change the top header section in the frontpage to apply our custom background color. Open the `assets/scss/<your instance shortname>/variables.scss` file and edit it as below:
 
-``` console
+``` scss
 $navbar_background_image: unset;
 $navbar_background_color: #000000; // Note this hex value is an example. Choose yours.
 ```
 
-Then, run the `invenio-cli update` command as above and refresh the page! You should be able to see your top header's color changed! You can find all the available variables that you can change [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/variables.scss).
+Then, run the `invenio-cli update` command as above and refresh the page! You should be able to see your top header's color changed! You can find all the available styling variables that you can change [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/variables.scss).
 
 ## Change search results
 
@@ -47,7 +52,7 @@ Changing how your results are presented in the search page is also something qui
 
 We are going to update the search result template so we can show more text in the result's description. Create a file called `ResultsItemTemplate.jsx` inside `assets/templates/search` folder and then edit it as below:
 
-```console
+```js
 import React from 'react';
 import {Item} from 'semantic-ui-react';
 import _truncate from 'lodash/truncate';
@@ -74,14 +79,14 @@ When you click on a search result, you navigate in the details page of a specifi
 
 We are going to configure our instance to use our template for displaying the information in the record's landing page. Open the `invenio.cfg` file and add the below:
 
-```console
+```python
 from invenio_rdm_records.config import RECORDS_UI_ENDPOINTS
 RECORDS_UI_ENDPOINTS['recid'].update(template='my_record_landing_page.html')
 ```
 
 Then, we create a file `my_record_landing_page.html` inside the `templates` folder and edit it as below:
 
-```console
+```jinja
 {%- extends 'invenio_rdm_records/record_landing_page.html' %}
 
 {%- block page_body %}
@@ -90,3 +95,20 @@ Then, we create a file `my_record_landing_page.html` inside the `templates` fold
 ```
 
 Inside the `page_body` block you can restructure the page as you want! You can check the default record landing page template [here](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html).
+
+Since we modified `invenio.cfg`, we need to re-start the server to see our changes take effect:
+
+```bash
+^C
+Stopping server and worker...
+Server and worker stopped...
+```
+```bash
+invenio-cli run
+```
+
+## Change functionality
+
+Need further customizations? Have you thought of creating your own extensions?
+
+How to make an extension and add it to your InvenioRDM instance is explained in the [Extensions section](../extensions/custom.md).

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -14,8 +14,10 @@ We start by creating a new project in a different folder. We will just follow wh
 did in the [Preview section](../preview/index.md). Feel free to use your own
 project name.
 
+``` bash
+invenio-cli init --flavour=RDM
+```
 ``` console
-$ invenio-cli init --flavour=RDM
 Initializing RDM application...
 project_name [My Site]: February Release 2
 project_shortname [february-release-2]:

--- a/docs/develop/install_locally.md
+++ b/docs/develop/install_locally.md
@@ -9,16 +9,19 @@ allowing you to iterate on your local instance quickly.
 
 Before going on, let's move into the project directory:
 
-``` console
-$ cd february-release-2
+``` bash
+cd february-release-2
 ```
 
 To run the application locally, we will need to install it and its dependencies
 first. We do not need to add `--pre`, since we do not have to install any alpha releases. Nonetheless, this option is still available if you need it. Be patient, it might take some time to build.
 
 
+``` bash
+invenio-cli install
+```
 ``` console
-$ invenio-cli install
+# Summarized output
 Installing python dependencies...
 Symlinking invenio.cfg...
 Symlinking templates/...
@@ -35,35 +38,67 @@ have been symlinked inside it.
 
 ## Setup the database, Elasticsearch, Redis and RabbitMQ
 
-We need to initialize the database, the indices and so on. For this, we can use
-the `services` command. Note that this command is only needed once. Afterwards, you
-can stop (not destroy) these services and start again, and your data will still be there.
+We need to initialize the database, the indices and so on. For this, we use
+the `services` command. The first time this command is run, the services will be
+setup correctly and the containers running them will even restart upon a reboot
+of your machine. If you stop and restart those containers, your data will still
+be there. Upon running this command again, the initial setup is skipped.
 
-``` console
-$ invenio-cli services
-Making sure containers are up...
-Creating database...
-Creating indexes...
-Creating files location...
-Creating admin role...
-Assigning superuser access to admin role...
+
+``` bash
+invenio-cli services
 ```
+``` console
+Making sure containers are up...
+Creating network "february-release-2_default" with the default driver
+Creating february-release-2_cache_1 ... done
+Creating february-release-2_es_1    ... done
+Creating february-release-2_db_1    ... done
+Creating february-release-2_mq_1    ... done
+Creating database postgresql+psycopg2://february-release-2:february-release-2@localhost/february-release-2
+Creating all tables!
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+Created all tables!
+Location default-location /your/path/to/var/instance/data as default True created
+Role "admin" created successfully.
+Creating indexes...
+Putting templates...
+```
+
+!!!note
+    You will notice `Making sure containers are up...` like the above and a 30s
+    delay in the output of the commands we cover next. This is because they make
+    doubly sure the containers are running. In future releases, we will reduce
+    this delay.
 
 In case you want to wipe out the data that was there (say to start fresh),
 you can use `--force` and nuke the content!
 
+``` bash
+invenio-cli services --force
+```
 ``` console
-$ invenio-cli services --force
 Making sure containers are up...
-Flushing redis cache...
-Deleting database...
-Deleting indexes...
-Purging queues...
-Creating database...
+february-release-2_mq_1 is up-to-date
+february-release-2_db_1 is up-to-date
+february-release-2_cache_1 is up-to-date
+february-release-2_es_1 is up-to-date
+Cache cleared
+Destroying database postgresql+psycopg2://february-release-2:february-release-2@localhost/february-release-2
+Destroying indexes...
+Indexing queue has been initialized.
+Indexing queue has been purged.
+Creating database postgresql+psycopg2://february-release-2:february-release-2@localhost/february-release-2
+Creating all tables!
+  [####################################]  100%
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+Created all tables!
+Location default-location /your/path/to/var/instance/data as default True created
+Role "admin" created successfully.
 Creating indexes...
-Creating files location...
-Creating admin role...
-Assigning superuser access to admin role...
+Putting templates...
 ```
 
 **Known issues**:
@@ -72,14 +107,14 @@ The Elasticsearch container might crash due to lack of memory. One solution is t
 
 On Linux, add the following to ``/etc/sysctl.conf`` on your local machine (host machine):
 
-```console
+```bash
 # Memory mapped max size set for ElasticSearch
 vm.max_map_count=262144
 ```
 
 On macOS, do the following:
 
-```console
+```bash
 screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
 # and in the shell
 sysctl -w vm.max_map_count=262144
@@ -90,10 +125,18 @@ sysctl -w vm.max_map_count=262144
 Let's add some content so you can interact a bit with the instance. For this
 you will generate 10 random demo records, using the `demo` command:
 
+``` bash
+invenio-cli demo --local
+```
 ``` console
-$ invenio-cli demo --local
 Making sure containers are up...
-Populating instance with demo records...
+february-release-2_mq_1 is up-to-date
+february-release-2_db_1 is up-to-date
+february-release-2_cache_1 is up-to-date
+february-release-2_es_1 is up-to-date
+Creating demo records...
+Created records!
+
 ```
 
 We are ready to run it in the next section.

--- a/docs/develop/run.md
+++ b/docs/develop/run.md
@@ -3,8 +3,11 @@
 Once the application is installed locally and the services are running, our
 application just needs to run. For that, the `run` command is executed.
 
+``` bash
+invenio-cli run
+```
 ``` console
-$ invenio-cli run
+# Summarized output
 Making sure containers are up...
 Starting celery worker...
 Starting up local (development) server...
@@ -20,8 +23,10 @@ Are we done? Yes, let the fun begin...
 
 Let's see what is in the instance by querying the API. Using another terminal:
 
-``` console
-$ curl -k -XGET https://localhost:5000/api/records/ | python3 -m json.tool
+``` bash
+curl -k -XGET https://localhost:5000/api/records/ | python3 -m json.tool
+```
+``` json
 {
     "aggregations": {
         "access_right": {
@@ -211,17 +216,16 @@ $ curl -k -XGET https://localhost:5000/api/records/ | python3 -m json.tool
 
 **Pro Tip**: You can use [jq](https://github.com/stedolan/jq) for color highlighting:
 
-```console
-$ curl -k -XGET https://localhost:5000/api/records/ | jq .
-...
+```bash
+curl -k -XGET https://localhost:5000/api/records/ | jq .
 ```
 
 ### Create records
 
 You can create a new record using the API:
 
-```console
-$ curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/records/ -d '{
+```bash
+curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/records/ -d '{
     "_access": {
         "metadata_restricted": false,
         "files_restricted": false
@@ -294,36 +298,127 @@ $ curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/
 
 And then search for it:
 
-``` console
-$ curl -k -XGET https://localhost:5000/api/records/?q=Romans | python3 -m json.tool
+``` bash
+curl -k -XGET https://localhost:5000/api/records/?q=Gladiator | python3 -m json.tool
+```
+``` json
 {
     "aggregations": {
-        [...]
+        "access_right": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "key": "open"
+                }
+            ],
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0
+        },
+        "resource_type": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "key": "image"
+                }
+            ],
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0
+        }
     },
     "hits": {
         "hits": [
             {
-                "created": "2019-12-19T13:05:48.479895+00:00",
-                "id": "pv1dx-rwa61",
+                "created": "2020-02-26T15:46:55.000116+00:00",
+                "id": "8wtcp-1bs44",
                 "links": {
-                    "self": "https://localhost:5000/api/records/pv1dx-rwa61"
+                    "files": "https://localhost:5000/api/records/8wtcp-1bs44/files",
+                    "self": "https://localhost:5000/api/records/8wtcp-1bs44"
                 },
                 "metadata": {
-                    [...]
-                    "titles": [{
-                        "title": "A Romans story",
-                        "type": "Other",
-                        "lang": "eng"
-                    }]
+                    "_access": {
+                        "files_restricted": false,
+                        "metadata_restricted": false
+                    },
+                    "_created_by": 1,
+                    "_owners": [
+                        1
+                    ],
+                    "access_right": "open",
+                    "community": {
+                        "primary": "Maincom",
+                        "secondary": [
+                            "Subcom One",
+                            "Subcom Two"
+                        ]
+                    },
+                    "creators": [
+                        {
+                            "affiliations": [
+                                {
+                                    "identifier": "entity-one",
+                                    "name": "Entity One",
+                                    "scheme": "entity-id-scheme"
+                                }
+                            ],
+                            "family_name": "Cesar",
+                            "given_name": "Julio",
+                            "identifiers": [
+                                {
+                                    "identifier": "9999-9999-9999-9999",
+                                    "scheme": "Orcid"
+                                }
+                            ],
+                            "name": "Julio Cesar",
+                            "type": "Personal"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "description": "A story on how Julio Cesar relates to Gladiator.",
+                            "lang": "eng",
+                            "type": "Abstract"
+                        }
+                    ],
+                    "identifiers": [
+                        {
+                            "identifier": "10.9999/rdm.9999999",
+                            "scheme": "DOI"
+                        },
+                        {
+                            "identifier": "9999.99999",
+                            "scheme": "arXiv"
+                        }
+                    ],
+                    "licenses": [
+                        {
+                            "identifier": "BSD-3",
+                            "license": "Berkeley Software Distribution 3",
+                            "scheme": "BSD-3",
+                            "uri": "https://opensource.org/licenses/BSD-3-Clause"
+                        }
+                    ],
+                    "publication_date": "2020-02-26",
+                    "recid": "8wtcp-1bs44",
+                    "resource_type": {
+                        "subtype": "photo",
+                        "type": "image"
+                    },
+                    "titles": [
+                        {
+                            "lang": "eng",
+                            "title": "A Romans story",
+                            "type": "Other"
+                        }
+                    ]
                 },
                 "revision": 0,
-                "updated": "2019-12-19T13:05:48.479900+00:00"
+                "updated": "2020-02-26T15:46:55.000119+00:00"
             }
         ],
         "total": 1
     },
     "links": {
-        "self": "https://localhost:5000/api/records/?sort=bestmatch&q=doge&size=10&page=1"
+        "self": "https://localhost:5000/api/records/?sort=bestmatch&q=Gladiator&size=10&page=1"
     }
 }
 ```
@@ -332,7 +427,7 @@ $ curl -k -XGET https://localhost:5000/api/records/?q=Romans | python3 -m json.t
 
 Alternatively, you can use the web UI.
 
-Navigate to https://localhost:5000/ . Note that you might need to accept the SSL exception since it's using a test certificate.
+Navigate to [https://localhost:5000](https://localhost:5000) . Note that you might need to accept the SSL exception since it's using a test certificate.
 And visit the record page for the newly created record. You will see it has no files associated with it. Let's change that!
 
 ### Upload a file to a record
@@ -341,25 +436,15 @@ For demonstration purposes, we will attach this scientific photo:
 
 ![Very scientific picture of a shiba in the snow](https://images.unsplash.com/photo-1548116137-c9ac24e446c9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80)
 
-By <a href="https://unsplash.com/@matyssik" target="_blank" rel="noopener noreferrer">Ian Matyssik</a>
+by <a href="https://unsplash.com/@matyssik" target="_blank" rel="noopener noreferrer">Ian Matyssik</a>.
 
 Save it as `snow_doge.jpg` in your current directory. Then upload it to the record:
 
 !!! warning "Change the `recid`"
     Change `pv1dx-rwa61` in the URLs below for the recid of your record.
 
-```
-$ curl -k -X PUT https://localhost:5000/api/records/pv1dx-rwa61/files/snow_doge.jpg -H "Content-Type: application/octet-stream" --data-binary @snow_doge.jpg
+``` bash
+curl -k -X PUT https://localhost:5000/api/records/pv1dx-rwa61/files/snow_doge.jpg -H "Content-Type: application/octet-stream" --data-binary @snow_doge.jpg
 ```
 
 This file can then be previewed on the record page and even downloaded.
-
-## Stop the instance
-
-We have reached the end of this journey, we are going to stop the instance. Nonetheless you can keep testing and playing around with configurations!
-
-``` console
-^C
-Stopping server and worker...
-Server and worker stopped...
-```

--- a/docs/develop/troubleshoot.md
+++ b/docs/develop/troubleshoot.md
@@ -1,18 +1,18 @@
 # Troubleshooting
 
-Something has gone wrong, now what? InvenioRDM provides logs in two ways, depending on where the error happened. If the error comes from the local development instance (`invenio-cli run`), your section is the [CLI](#cli). On the other hand, if once the fully containerized application is running (`invenio-cli containerize`) you get an error, you should go to the [Web Application](#web-application) section.
-
-## CLI
-
-All the logs show up in the terminal at the same time that you execute the commands.
+Something has gone wrong, now what? InvenioRDM provides logs in two ways, depending on where the error happened.
+If the error comes from the local development instance (`invenio-cli run`), look at the terminal, the logs show up there.
+On the other hand, if the error comes from the fully containerized application (`invenio-cli containerize`), you won't see logs on the terminal directly.
+See below.
 
 ## Web Application
 
 If you are running the containerized environment you need to get the logs from the corresponding containers. It can be done in two steps, first obtaining the container IDs and then getting their logs:
 
+``` bash
+docker ps -a
+```
 ``` console
-$ docker ps -a
-
 CONTAINER ID        IMAGE                                                     COMMAND                  CREATED             STATUS                           PORTS                                                                                        NAMES
 5cb64814ed2a        my-site-frontend                                          "nginx -g 'daemon of…"   24 minutes ago      Up 1 minute                                                                                                                   mysite_frontend_1
 39993dcbb84f        my-site                                                   "bash -c 'celery wor…"   24 minutes ago      Up 1 minute                                                                                                                   mysite_worker_1
@@ -26,9 +26,10 @@ cbdac8cbd6a9        rabbitmq:3-management                                     "d
 
 The most interesting ones will be the `web-ui` and `web-api` containers, which in this case have id `a99532c10a8b` and `ff9a589845e4` respectively. The logs can be obtained by using the `logs` command of `docker`. An example of a working instance of the `web-api` container would show the following (trimmed output for clarity):
 
+``` bash
+docker logs ff9a589845e4
+```
 ``` console
-$ docker logs ff9a589845e4
-
 [uWSGI] getting INI configuration from /opt/invenio/var/instance/uwsgi_rest.ini
 *** Starting uWSGI 2.0.18 (64bit) on [Wed Jan  8 13:09:07 2020] ***
 [...]

--- a/docs/extensions/custom.md
+++ b/docs/extensions/custom.md
@@ -5,10 +5,8 @@ If you want to add custom functionality to your RDM instance, you need to develo
 ## Create your module
 Let's run the cookiecutter:
 
-``` console
-$ cookiecutter https://github.com/inveniosoftware/cookiecutter-invenio-module
-
-[...]
+``` bash
+cookiecutter https://github.com/inveniosoftware/cookiecutter-invenio-module
 ```
 
 ## Add your functionality
@@ -34,9 +32,9 @@ def index():
 
 Once you have your functionality ready, in order to add it to your instance you just have to install the module via pipenv:
 
-``` console
-$ cd path/to/your/instance
-$ pipenv install [--pre] -e path/to/your/extension
+``` bash
+cd path/to/your/instance
+pipenv install [--pre] -e path/to/your/extension
 ```
 
 As you can see, `--pre` is optional. It is only needed when the package is in a pre-release state. In addition, note that you do not need to specify a local path. If the package is available e.g. via PyPi, you can just install it by its name.
@@ -56,8 +54,8 @@ invenio-rdm-extension-demo = {editable = true, path="../invenio-rdm-ext-demo"}
 
 It's all set, run your instance with the cli and you will have your new features available!
 
-``` console
-$ invenio-cli run
+``` bash
+invenio-cli run
 ```
 
 !!! note "UI related extensions"

--- a/docs/extensions/s3.md
+++ b/docs/extensions/s3.md
@@ -10,8 +10,8 @@ InvenioRDM uses a [MinIO](https://min.io/download) container for S3-like storage
 
 a. Install the [mc tool](https://docs.min.io/docs/minio-client-quickstart-guide.html) and run the following command, where `default-bucket` is the name of your bucket.
 
-``` console
-$ mc mb default-bucket
+``` bash
+mc mb default-bucket
 ```
 
 b. Use the web UI (https://localhost[:9000]/minio). In the bottom right you will see a `+` sign, click there and add a new bucket.
@@ -20,16 +20,16 @@ b. Use the web UI (https://localhost[:9000]/minio). In the bottom right you will
 
 Now you need to tell InvenioRDM where that bucket is. For that, create a new location. If you are running a local (development) instance, run:
 
-``` console
-$ cd path/to/your/instance
-$ pipenv run invenio files location create s3-default s3://default-bucket --default
+``` bash
+cd path/to/your/instance
+pipenv run invenio files location create s3-default s3://default-bucket --default
 ```
 
 If you are running the containerized version, run:
 
-``` console
-$ docker exec -it <web_[api|ui] container name or id> /bin/bash
-$ invenio files location create s3-default s3://default-bucket --default
+``` bash
+docker exec -it <web_[api|ui] container name or id> /bin/bash
+invenio files location create s3-default s3://default-bucket --default
 ```
 
 ### Set your credentials
@@ -42,6 +42,6 @@ It's done! Ready to roll!
 
 ## I didn't choose S3 when initializing
 
-You are here, but do not panic, is not difficult just longer.
+You are here, but do not panic, it's not difficult just longer.
 
 Coming soon.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -18,8 +18,8 @@ Some system requirements are needed beforehand:
 In addition, make sure the user that will be executing the CLI has access to
 the docker command (i.e. it is not only available for the root user):
 
-```console
-$ sudo usermod --append --groups docker $USER
+```bash
+sudo usermod --append --groups docker $USER
 ```
 
 !!! note "Hardware requirements"
@@ -35,26 +35,28 @@ Use your favorite way to install a Python package:
 
 Via pip:
 
-``` console
-$ pip install invenio-cli
+``` bash
+pip install invenio-cli
 ```
 
 Via pipenv:
 
-``` console
-$ pipenv install invenio-cli
+``` bash
+pipenv install invenio-cli
 ```
 
 Via pipx:
 
-``` console
-$ pipx install invenio-cli
+``` bash
+pipx install invenio-cli
 ```
 
 To make sure you've installed successfully:
 
+``` bash
+invenio-cli --version
+```
 ``` console
-$ invenio-cli --version
 invenio-cli, version 0.10.1
 ```
 

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -28,8 +28,10 @@ It will also generate a test private key.
 
 Let's do it! Pressing `[Enter]` selects the option in brackets `[]`.
 
+``` bash
+invenio-cli init --flavour=RDM
+```
 ``` console
-$ invenio-cli init --flavour=RDM
 Initializing RDM application...
 project_name [My Site]: February Release
 project_shortname [february-release]:
@@ -68,8 +70,10 @@ Creating logs directory...
 
 Observe the generated files. A full description of each of them can be found in the [invenio-cli RFC](https://github.com/inveniosoftware/rfcs/pull/4)
 
+``` bash
+ls -la february-release
+```
 ``` console
-$ ls -la february-release
 total 56
 drwxr-xr-x 5 youruser youruser 4096 Feb 19 13:45 ./
 drwxr-xr-x 5 youruser youruser 4096 Feb 19 13:45 ../
@@ -103,21 +107,25 @@ drwxr-xr-x 2 youruser youruser 4096 Feb 19 13:45 templates/
 The project is initialized, we just need to run it. Switch to the project
 directory and do so:
 
+``` bash
+cd february-release
+invenio-cli containerize
+```
 ``` console
-$ cd february-release
-$ invenio-cli containerize
 <... build output ignored ...>
 Instance running!
 Visit https://localhost
-$ firefox https://localhost
+```
+``` bash
+firefox https://localhost
 ```
 
 You now have a running instance of InvenioRDM at [https://localhost](https://localhost),
 but it doesn't have any records in it. For demonstration purposes, we will add
 randomly generated records:
 
-``` console
-$ invenio-cli demo --containers
+``` bash
+invenio-cli demo --containers
 ```
 
 You can now get a full sense for what InvenioRDM offers and explore.
@@ -130,9 +138,9 @@ provides, you might be wondering how to execute those. Because the entire applic
 is containerized, you need to connect to the web-api or web-ui container in order
 to use one of those commands. In fact, this is what `invenio-cli` does behind the scene!
 
-``` console
-$ docker exec -it <container name or id> /bin/bash
-# invenio <your command>
+``` bash
+docker exec -it <container name or id> /bin/bash
+invenio <your command>
 ```
 
 You can use `docker ps` to get the name or id of the web-api or web-ui container.
@@ -142,14 +150,10 @@ You can use `docker ps` to get the name or id of the web-api or web-ui container
 
 In just two commands you can get a preview of InvenioRDM:
 
-``` console
-$ invenio-cli init --flavour=RDM
-$ cd <project name>
-$ invenio-cli containerize
-<... build output ignored ...>
-Instance running!
-Visit https://localhost
-$ firefox https://localhost
+``` bash
+invenio-cli init --flavour=RDM
+cd <project name>
+invenio-cli containerize
 ```
 
 These instructions don't provide you with a nice development experience though.


### PR DESCRIPTION
- Separate commands to be entered (`bash` syntax to pop) and
  returned output (`console` syntax to be muted), so that commands can be
  copied via the clipboard icon directly. Closes #6
- Removed permission configuration advanced example temporarily given it wasn't
  working.
- Documented more details of the workflow:
    * how checking for running containers incurs a 30s delay
    * how server must be stopped and started whenever invenio.cfg is changed
- Moved some small sections around for clarity and focus.
- Did a pass at all syntax highlighting to make everything pop
  as much as possible (jsx doesn't work so broken js was used for jsx :shrug:)

Easiest way to assess is by running it locally.