### PR TITLE
pre-requirements: bump deprecated versions

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -8,7 +8,7 @@ command line tool for creating and updating your instance.
 Some system requirements are needed beforehand:
 
 - [Python](https://www.python.org/) (3.6.2 <= supported version < 3.7.0 only)
-- [nodejs](https://nodejs.org) (8.0.0+) (not needed to preview, only needed to develop)
+- [nodejs](https://nodejs.org) (10.0.0+) (not needed to preview, only needed to develop)
 - [Docker](https://docs.docker.com/) (1.13.0+)
 - [Docker-Compose](https://docs.docker.com/compose/) (1.17.0+)
 


### PR DESCRIPTION
In the docs it is stated:

```
Python (3.6.2 <= supported version < 3.7.0 only)
nodejs (8.0.0+) (not needed to preview, only needed to develop)
Docker (1.13.0+)
Docker-Compose (1.17.0+)
```

As discussed IRL, Python 3.7 support cannot still be said since there is no docker image for it.
nodejs 8 is out of support https://nodejs.org/es/about/releases/. Between us and the Zenodo team we have run RDM in node versions 7, 8, 11, 12 and 13. Any of you @fenekku @zzacharo with node 10?

Docker support seems fine. It is running fine also with but I see no need to bump those since my old laptop IIRC was the lowest (the current ones on the website) and it was running fine:
```
Docker version 19.03.8, build afacb8b
docker-compose version 1.25.4, build 8d51620a
```

Closes https://github.com/inveniosoftware/docs-invenio-rdm/issues/32