### PR TITLE
deployment: building images and pushing to a registry

### DIFF
--- a/docs/deployment/image.md
+++ b/docs/deployment/image.md
@@ -1,0 +1,18 @@
+# Build your instance Docker image
+
+In this section you will learn to build the docker image of your InvenioRDM instance! Doing so is as simple as running the following command:
+
+``` console
+docker build -t demo-inveniordm /path/to/your/instance --build-arg include_assets=true
+```
+
+!!! info "Tag name"
+    In this case we have chosen to call our image `demo-inveniordm`, but you can choose your own name.
+
+**Why is the `include_assets` flag needed**
+
+When running InvenioRDM in local (`invenio-cli run`) you are running the uWSGI server in your own machine. On the other hand, when running `invenio-cli containerize` you are building the docker image. Then you are runing it in your machine along the other containers. Nonetheless, the statics are built in a different fashion. However, when deploying somewhere else they are needed. 
+
+This is the case when deploying in OpenShift. To solve this problem the charts define a share volume mounted on the Nginx and the Web containers. 
+
+When a volume is mounted it overwrites the contents of the folder (i.e. it will delete the assets). Therefore, we make use of an `initContainer` to mount the volume in a temporary location and copy to the volume the assets. This way when the volume is mounted into Nginx and Web containers it already has the assets. Being the end result that `/static` files can be served directly by Nginx.

--- a/docs/deployment/image.md
+++ b/docs/deployment/image.md
@@ -11,8 +11,8 @@ docker build -t demo-inveniordm /path/to/your/instance --build-arg include_asset
 
 **Why is the `include_assets` flag needed**
 
-When running InvenioRDM in local (`invenio-cli run`) you are running the uWSGI server in your own machine. On the other hand, when running `invenio-cli containerize` you are building the docker image. Then you are runing it in your machine along the other containers. Nonetheless, the statics are built in a different fashion. However, when deploying somewhere else they are needed. 
+When running InvenioRDM in local (`invenio-cli run`), you are running the uWSGI server on your own machine where you have built the statics. On the other hand, when running `invenio-cli containerize` you are building the docker image and then running it along the other containers. There, `invenio-cli` takes care of building the statics in the mounted volume for you. However, when building the image on your own (e.g. deploying somewhere else), you need to take care of the statics yourself.
 
-This is the case when deploying in OpenShift. To solve this problem the charts define a share volume mounted on the Nginx and the Web containers. 
+This is the case when deploying in OpenShift. To solve this problem the chart defines a shared volume mounted on the Nginx and the Web containers.
 
 When a volume is mounted it overwrites the contents of the folder (i.e. it will delete the assets). Therefore, we make use of an `initContainer` to mount the volume in a temporary location and copy to the volume the assets. This way when the volume is mounted into Nginx and Web containers it already has the assets. Being the end result that `/static` files can be served directly by Nginx.

--- a/docs/deployment/openshift.md
+++ b/docs/deployment/openshift.md
@@ -78,6 +78,9 @@ worker:
   image: your/invenio-image
 ```
 
+!!! info "Image registries"
+    You can get to know more about where and how to store you instance's docker image [here](./registries).
+
 The next step is the installation itself, with your own configuration in the `values.yaml`. If you added the repository, you can install it by using the chart name and the desired version:
 
 ``` console

--- a/docs/deployment/registries.md
+++ b/docs/deployment/registries.md
@@ -1,0 +1,116 @@
+# Image registries
+
+There are several places where you can store your docker image. In this section, we cover some of the most known ones.
+However, you can use any other of your preference.
+
+!!! warning "Build your image before hand"
+    In the following documentation we are assuming that you have already built your docker image.
+    You can find documentation on how to do it [here](./image.md).
+
+## DockerHub
+
+To use docker hub, follow Docker's [official documentation](https://docs.docker.com/docker-hub/repos/).
+
+## GitHub
+
+To store your image in GitHub you will need a repository. You can use your instance's one. For example:
+*https://github/yourusername/rdmrepo*. In addition, you will need to [create an access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). This access token must have
+`read:packages` and `write:packages` scopes.
+
+The first step is to login in GitHub's docker registry:
+
+``` console
+$ docker login docker.pkg.github.com -u <YOU_GITHUB_USERNAME> -p <YOUR_GITHUB_TOKEN>
+```
+
+Then find your docker image and tag it you the url of your GitHub registry:
+
+```
+$ docker images
+REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
+demo-inveniordm                                     latest              9b6dd5ae6b48        17 hours ago        2.33GB
+
+$ docker tag demo-inveniordm docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
+```
+
+!!! info "Project name"
+    Note that `rdmrepo` is the name of your GitHub repository. Therefore the tag is: ``docker.pkg.github.co/<your_github_user_name>/<your_github_repo_name>/<your_image_name>:<version>``
+
+Check that it was tagged correctly:
+
+``` console
+$ docker images                                                                   
+REPOSITORY                                                      TAG                 IMAGE ID            CREATED             SIZE
+demo-inveniordm                                                 latest              9b6dd5ae6b48        17 hours ago        2.33GB
+docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest      latest              9b6dd5ae6b48        17 hours ago        2.33GB
+```
+
+The last step is to push your package to the github registry:
+
+``` console
+docker push docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
+```
+
+In order to use this image, you must set the following value in your `values.yaml` file (for both `web` and `worker`):
+
+```
+image: docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest 
+```
+
+Even if your project and/or image is public, GitHub requires you to be authenticated in order to pull your image.
+In OpenShift you can change the default pulling configuration so that it uses your token. You can do so as follows:
+
+``` console
+$ oc create secret docker-registry <SECRET_NAME> \
+    --docker-server=docker.pkg.github.com \
+    --docker-username=<YOUR_GITHUB_USERNAME> \
+    --docker-password=<YOUR_GITHUB_PASSWORD>
+$ oc secrets link default <SECRET_NAME> --for=pull \
+    --namespace=<YOUR_OPENSHIFT_PROJECT_NAME>
+```
+
+## OpenShift
+
+First you need to login in your OpenShift cluster and its image registry:
+
+``` console
+$ docker login -u openshift -p $(oc whoami -t) <registry_ip>:<port>
+$ oc login
+$ oc project
+Using project "inveniordm" on server "<registry_ip>:<port>".
+```
+
+Then find your docker image and tag it you the url of your OpenShift registry:
+
+``` console
+$ docker images
+REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
+demo-inveniordm                                     latest              9b6dd5ae6b48        17 hours ago        2.33GB
+
+$ docker tag demo-inveniordm <registry_ip>:<port>/inveniordm/demo-inveniordm:latest
+```
+
+!!! info "Project name"
+    Note that `inveniordm` is the name of the OpenShift project we are using. It's value should be the one returned
+    by the `oc project` command. Therefore the tag is: ``<registry_ip>:<port>/<project_name>/<name_of_your_image>:<version>``
+
+Check that it was tagged correctly:
+
+``` console
+$ docker images                                                                   
+REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
+demo-inveniordm                                     latest              9b6dd5ae6b48        17 hours ago        2.33GB
+<registry_ip>:<port>/inveniordm/demo-inveniordm     latest              9b6dd5ae6b48        17 hours ago        2.33GB
+```
+
+Finally push it to the image registry of OpenShift:
+
+``` console
+$ docker push <registry_ip>:<port>/inveniordm/demo-inveniordm:latest 
+```
+
+In order to use this image, you must set the following value in your `values.yaml` file (for both `web` and `worker`):
+
+``` console
+image: <registry_ip>:<port>/inveniordm/demo-inveniordm:rdm 
+```

--- a/docs/deployment/registries.md
+++ b/docs/deployment/registries.md
@@ -17,13 +17,13 @@ To store your image in GitHub you will need a repository. You can use your insta
 *https://github/yourusername/rdmrepo*. In addition, you will need to [create an access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). This access token must have
 `read:packages` and `write:packages` scopes.
 
-The first step is to login in GitHub's docker registry:
+The first step is to log in to GitHub's docker registry:
 
 ``` console
 $ docker login docker.pkg.github.com -u <YOU_GITHUB_USERNAME> -p <YOUR_GITHUB_TOKEN>
 ```
 
-Then find your docker image and tag it you the url of your GitHub registry:
+Then, find your docker image and tag it with the url of your GitHub registry:
 
 ```
 $ docker images
@@ -45,7 +45,7 @@ demo-inveniordm                                                 latest          
 docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest      latest              9b6dd5ae6b48        17 hours ago        2.33GB
 ```
 
-The last step is to push your package to the github registry:
+The last step is to push your package to the GitHub registry:
 
 ``` console
 docker push docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
@@ -54,7 +54,11 @@ docker push docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
 In order to use this image, you must set the following value in your `values.yaml` file (for both `web` and `worker`):
 
 ```
-image: docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest 
+web:
+    image: docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
+
+worker:
+    image: docker.pkg.github.com/yourusername/rdmrepo/rdmimage:latest
 ```
 
 Even if your project and/or image is public, GitHub requires you to be authenticated in order to pull your image.
@@ -71,7 +75,7 @@ $ oc secrets link default <SECRET_NAME> --for=pull \
 
 ## OpenShift
 
-First you need to login in your OpenShift cluster and its image registry:
+First you need to log in to your OpenShift cluster and its image registry:
 
 ``` console
 $ docker login -u openshift -p $(oc whoami -t) <registry_ip>:<port>
@@ -80,7 +84,7 @@ $ oc project
 Using project "inveniordm" on server "<registry_ip>:<port>".
 ```
 
-Then find your docker image and tag it you the url of your OpenShift registry:
+Then, find your docker image and tag it with the url of your OpenShift registry:
 
 ``` console
 $ docker images
@@ -91,7 +95,7 @@ $ docker tag demo-inveniordm <registry_ip>:<port>/inveniordm/demo-inveniordm:lat
 ```
 
 !!! info "Project name"
-    Note that `inveniordm` is the name of the OpenShift project we are using. It's value should be the one returned
+    Note that `inveniordm` is the name of the OpenShift project we are using. Its value should be the one returned
     by the `oc project` command. Therefore the tag is: ``<registry_ip>:<port>/<project_name>/<name_of_your_image>:<version>``
 
 Check that it was tagged correctly:
@@ -112,5 +116,9 @@ $ docker push <registry_ip>:<port>/inveniordm/demo-inveniordm:latest
 In order to use this image, you must set the following value in your `values.yaml` file (for both `web` and `worker`):
 
 ``` console
-image: <registry_ip>:<port>/inveniordm/demo-inveniordm:rdm 
+web:
+    image: <registry_ip>:<port>/inveniordm/demo-inveniordm:rdm
+
+worker:
+    image: <registry_ip>:<port>/inveniordm/demo-inveniordm:rdm
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,8 @@ nav:
     - Kubernetes: 'deployment/kubernetes.md'
     - System components: 'deployment/services.md'
     - Configuration:  'deployment/configuration.md'
+    - Building your image: 'deployment/image.md'
+    - Image registries: 'deployment/registries.md'
     - Benchmarking: 'deployment/benchmark.md'
 
 


### PR DESCRIPTION
This PR adds documentation on how to build the docker image for InvenioRDM and how to push it to several registries (GitHub, OpenShift and DockerHub).

Requires: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/56

**Question**:
Since GitHub requires a password/token stored in OpenShift. Options are:

a. We can leave it as is, and make the user build the image (2-3 mins) and push it to a registry.
b. Build the default image (that we have to do anyway) and push it to DockerHub so everybody has access to pull it.

Note: if we opt for a we can just push our image to CERN OpenShift or CERN GitLab registry.

WDYT? @lnielsen @zzacharo @fenekku 

Decision will close https://github.com/inveniosoftware/demo-inveniordm/issues/7