### PR TITLE
global: fix outputs and commands to align with v0.7.0

### DIFF
--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -421,6 +421,16 @@ in the dropdown menu of the username (top-right), select `Applications`. Then
 click on `New token`, name your token and click `Create`. Copy this token (we
 will refer to it as `<your token>`) and put it in the API call as such:
 
+Alternatively, you can get a token using the invenio command, where `-n` is
+the name of the token (your choice) and `-u` the email of the user created
+right before.
+
+``` bash
+ pipenv run invenio tokens create -n permission-demo -u admin@test.ch
+ ```
+
+Then use the obtained token to perform the query:
+
 ``` bash
 curl -k -XPOST -H "Authorization:Bearer <your token>" -H "Content-Type: application/json" https://localhost:5000/api/records/ -d '{
     ...<fill with the above>...

--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -270,7 +270,14 @@ curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/re
     "_owners": [1],
     "_created_by": 1,
     "access_right": "open",
+    "community": {
+        "primary": "Maincom",
+        "secondary": ["Subcom One", "Subcom Two"]
+    },
     "creators": [],
+    "identifiers": {
+        "DOI": "10.9999/rdm.9999999"
+    },
     "resource_type": {
         "type": "image",
         "subtype": "image-photo"
@@ -280,6 +287,13 @@ curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/re
         "type": "Other",
         "lang": "eng"
     }],
+    "descriptions": [
+        {
+            "description": "A story on how Julio Cesar relates to Gladiator.",
+            "type": "Abstract",
+            "lang": "eng"
+        }
+    ],
     "extensions": {
         "dwc:family": "Felidae",
         "dwc:behavior": "Plays with yarn, sleeps in cardboard box.",


### PR DESCRIPTION
- Add token creation through CLI
- Add description to POST operations to avoid breaking search UI. It is used [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/templates/search/ResultsItemTemplate.jsx). Two options, make it not mandatory, somehow people should reimplement their UI templates if they don't want it?
- Add identifiers and community fields. Records landing page template is not yet ready to be rendered without this fields. https://github.com/inveniosoftware/invenio-rdm-records/issues/70