### PR TITLE
extensions: add required 'creators'

### DIFF
--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -270,6 +270,7 @@ curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/re
     "_owners": [1],
     "_created_by": 1,
     "access_right": "open",
+    "creators": [],
     "resource_type": {
         "type": "image",
         "subtype": "image-photo"


### PR DESCRIPTION
Adds missing "creators" to record creation example of extensions section.

See https://github.com/inveniosoftware/invenio-rdm-records/issues/86 for next steps to do next month.