### PR TITLE
global: several updates on endpoints and python versions

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -55,7 +55,7 @@ author_email [info@development-instance.com]:
 year [2020]:
 Select python_version:
 1 - 3.6
-2 - 3.7 (beta)
+2 - 3.7
 3 - 3.8 (beta)
 Choose from 1, 2, 3 [1]:
 Select database:

--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -312,7 +312,7 @@ class MyRecordPermissionPolicy(RDMRecordPermissionPolicy):
 RECORDS_PERMISSIONS_RECORD_POLICY = MyRecordPermissionPolicy
 ```
 
-and re-start the server.
+For demo purposes *any user* can currently *publish* a draft. If you want to change that to only admins too, you need to also add `can_publish = [SuperUser()]` to the above policy. Then re-start the server.
 
 When we set `RECORDS_PERMISSIONS_RECORD_POLICY = MyRecordPermissionPolicy`,
 we are overriding `RECORDS_PERMISSIONS_RECORD_POLICY` provided by

--- a/docs/develop/run.md
+++ b/docs/develop/run.md
@@ -77,7 +77,7 @@ curl -k -XGET https://localhost:5000/api/rdm-records | python3 -m json.tool
                 "created": "2020-02-25T15:54:52.127129+00:00",
                 "updated": "2020-02-25T15:54:52.127134+00:00",
                 "revision": 0,
-                "id": "zgxnf-z7n12",
+                "pid": "zgxnf-z7n12",
                 "links": {
                     "files": "https://localhost:5000/api/records/zgxnf-z7n12/files",
                     "self": "https://localhost:5000/api/records/zgxnf-z7n12"
@@ -229,7 +229,7 @@ curl -k -XGET https://localhost:5000/api/rdm-records | jq .
 You can create a new record **draft** using the API:
 
 ```bash
-curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/rdm-records/ -d '{
+curl -k -XPOST -H "Content-Type: application/json" https://localhost:5000/api/rdm-records -d '{
     "_access": {
         "metadata_restricted": false,
         "files_restricted": false
@@ -300,7 +300,7 @@ curl -k -X POST https://localhost:5000/api/rdm-records/jnmmp-51n47/draft/actions
 And then search for it:
 
 ``` bash
-curl -k -XGET https://localhost:5000/api/records/?q=Gladiator | python3 -m json.tool
+curl -k -XGET https://localhost:5000/api/rdm-records?q=Gladiator | python3 -m json.tool
 ```
 ``` json
 {
@@ -330,7 +330,7 @@ curl -k -XGET https://localhost:5000/api/records/?q=Gladiator | python3 -m json.
         "hits": [
             {
                 "created": "2020-02-26T15:46:55.000116+00:00",
-                "id": "jnmmp-51n47",
+                "pid": "jnmmp-51n47",
                 "links": {
                     "files": "https://localhost:5000/api/records/8wtcp-1bs44/files",
                     "self": "https://localhost:5000/api/records/8wtcp-1bs44"
@@ -418,7 +418,7 @@ And visit the record page for the newly created record. You will see it has no f
 
 ### Upload a file to a record
 
-!!! warning "Temporarily disabled!"
+!!! error "Temporarily not supported"
     This is temporarily disabled until the new API is fully compatible with it.
 
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -7,7 +7,7 @@ command line tool for creating and updating your instance.
 
 Some system requirements are needed beforehand:
 
-- [Python](https://www.python.org/) 3.6.2+ (Docker images are available for Python 3.6, 3.7 and 3.8. However, the latest is in beta testing phase).
+- [Python](https://www.python.org/) 3.6.2+ (Docker images are available for Python 3.6, 3.7 and 3.8. However, Python 3.8 is in beta testing phase).
 - [nodejs](https://nodejs.org) 13.0.0+ (not needed to preview, only needed to develop)
 - [Docker](https://docs.docker.com/) 1.13.0+
 - [Docker-Compose](https://docs.docker.com/compose/) 1.17.0+

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -7,7 +7,7 @@ command line tool for creating and updating your instance.
 
 Some system requirements are needed beforehand:
 
-- [Python](https://www.python.org/) 3.6.2+ (Python 3.7 has been tested successfully. However, there is still no docker image available and therefore is only available for development).
+- [Python](https://www.python.org/) 3.6.2+ (Docker images are available for Python 3.6, 3.7 and 3.8. However, the latest is in beta testing phase).
 - [nodejs](https://nodejs.org) 13.0.0+ (not needed to preview, only needed to develop)
 - [Docker](https://docs.docker.com/) 1.13.0+
 - [Docker-Compose](https://docs.docker.com/compose/) 1.17.0+

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -20,7 +20,7 @@ The CLI will require the following data:
 - **Author name**: Your name or that of your organization
 - **Author email**: Email for communication
 - **Year**: The current year
-- **Python version**: 3.6 (default), 3.7 (only available for [development](../develop/index.md)) and 3.8 (untested).
+- **Python version**: 3.6 (default), 3.7 and 3.8 (beta).
 - **One of the three available storage systems**: postgresql (default), mysql or sqlite
 - **The version of Elasticsearch**: 7 (default) or 6
 - **Storage backend**: Local file system (default) or in a S3-like backend. If S3 is chosen a MinIO container is provided, however, you can set it up to use your own. See more in [S3 extension](../extensions/s3.md)
@@ -28,9 +28,6 @@ The CLI will require the following data:
 It will also generate a test private key.
 
 Let's do it! Pressing `[Enter]` selects the option in brackets `[]`.
-
-!!! warning "Choose Python 3.6"
-    This tutorial takes you through the creation of a containerized instance. Therefore, only Python 3.6 is supported, if you wish to use other versions please follow the [development](../develop/index.md) tutorial.
 
 ``` bash
 invenio-cli init rdm
@@ -49,7 +46,7 @@ author_email [info@inveniordm-preview.com]:
 year [2020]:
 Select python_version:
 1 - 3.6
-2 - 3.7 (beta)
+2 - 3.7
 3 - 3.8 (beta)
 Choose from 1, 2, 3 [1]:
 Select database:


### PR DESCRIPTION
**NOTE**: We have configured `/rdm-records` without end slash and there is no redirect. We should fix that for next release.