### PR TITLE
November release review

### DIFF
--- a/docs/develop/cleanup.md
+++ b/docs/develop/cleanup.md
@@ -18,5 +18,5 @@ It destroys the images, containers and volumes defined in the `development-insta
 After stopping the application per above, destroy it:
 
 ``` bash
-invenio-cli destroy [--local | --containers]
+invenio-cli destroy
 ```

--- a/docs/develop/edit_a_module.md
+++ b/docs/develop/edit_a_module.md
@@ -1,0 +1,75 @@
+# Develop or edit a module
+
+Customization might not be enough for you, you are implementing a feature or
+fixing a bug. The point is that you need to install a module from a local path
+and see the changes reflected on your instance.
+
+If it is a backend change, simply installing the module from the local path
+should be enough. In some corner cases, you might have to re-start the
+instance (for that run `stop` and `run` again). For frontend (e.g. templates,
+css, etc.) you need to symlink and re-build the assets. This can be a complex
+process when using webpack, but Invenio-CLI got you covered.
+
+## Templates and CSS
+
+First you have to install the module you want to edit:
+
+```
+pip install ../path/to/new-module
+```
+
+Then you have to clean the assets (`--force` or `-f`), and create symbolic links
+(`--development` or `-d`). Cleaning the assets is required for two reasons, first the
+module might have been already installed from upstream and therefore some
+links already exist, or these files can already exist (as hard copies) if the
+installation was not done using the `--development` flag. As you can see, many
+things can go wrong so cleaning the assets is the wise thing to do:
+
+```
+invenio-cli assets update --development --force
+```
+
+In addition, if you want to modify CSS and see it when reloading the page you
+need to *watch* the assets. This will automatically rebuild the webpack bundles
+when you change the CSS (less) files. In order to watch them, open another
+terminal in your instance path (*development-instance* in the previous examples)
+and activate the same virtual environment. Then run:
+
+!!! warning "No hot reloading"
+    There is no hot reloading available, this means that even if the assets
+    are watched an rebuilt, you need to refresh your browser to see the
+    changes. In addition, **be aware of the cache**, it might be a good idea
+    to use an incognito window when developing web UI.
+
+```
+invenio-cli assets watch
+```
+
+Note that this is a long running operation, so do not close the terminal. You
+will be able to see the rebuilding progress there usually a `xy%` in the last
+line, and the errors in case there were any.
+
+!!! warning "You might see an UnfinishedManifest error"
+    Rebuilding the webpack bundles is not a speed-of-light operation, it might
+    take a few seconds. If you see an `UnfinishedManifest` error in your
+    browser first check the terminal to see that there were no build errors
+    (e.g. syntax errors) and then wait for it to be finished.
+
+## React modules
+
+In a similar fashion than in the previous section, to develop on a react
+module you have to install and watch it. Invenio-CLI has commands for that
+too. To install a module run:
+
+```
+invenio-cli install-module ../path/to/react-module
+```
+
+Then you have to watch it. open another terminal in your instance path
+(*development-instance* in the previous examples) and activate the same
+virtual environment. Note that if you are already watching some python
+module, this action is independent (and per module):
+
+```
+invenio-cli watch-module  react-module
+```

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -14,29 +14,6 @@ We start by creating a new project in a different folder. We will follow what we
 did in the [Preview section](../preview/index.md). Feel free to use your own
 project name.
 
-!!! warning "Pre-requisite: set FLASK_ENV=development"
-    To be able to modify assets and work on dependent modules, the environment variable
-    `FLASK_ENV` must be set to `development` in your shell for all subsequent operations.
-    This was not needed when running `invenio-cli containerize` since everything runs in
-    containers and you are not developing. We show how to do so below, but you can also
-    consult the [development setup page](https://github.com/inveniosoftware/invenio-app-rdm/wiki/Development-Setup)
-    for more up-to-date and advanced information.
-
-We need to set the `FLASK_ENV` environment variable. Make sure you do so in each terminal you are
-running `invenio-cli` commands from now on.
-
-With the bash shell:
-
-``` bash
-export FLASK_ENV=development
-```
-
-With the fish shell:
-
-```fish
-set --export FLASK_ENV development
-```
-
 Then we can run the initialization command:
 
 ``` bash

--- a/docs/develop/install_locally.md
+++ b/docs/develop/install_locally.md
@@ -14,12 +14,22 @@ cd development-instance
 ```
 
 To run the application locally, we will need to install it and its dependencies
-first. For this release, we will need to add `--pre`, since we do have to install alpha releases. Be patient, it might take some time to build.
+first. For this release, we will need to add `--pre`, since we do have to
+install alpha releases. Be patient, it might take some time to build.
 
+!!! info "Pre-requisite: FLASK_ENV is available via invenio-cli flags"
+    You do not need to export `FLASK_ENV` anymore, just call the commands with
+    `--development` or `-d`.
+    To be able to modify assets and work on dependent modules, the environment
+    variable `FLASK_ENV` must be set to `development`. This will instruct the
+    different commands to create symbolic links to your files so the changes
+    are easily propagated. There are two operations that require this flag:
+    `install` and `update`.
 
 ``` bash
-invenio-cli install --pre
+invenio-cli install --pre --development
 ```
+
 ``` console
 # Summarized output
 Installing python dependencies...
@@ -34,14 +44,17 @@ Built webpack project.
 ```
 
 As a result, the Python dependencies for the project have been installed in
-a new virtualenv for the application and many of the files in your project directory
-have been symlinked inside it.
+a new virtualenv for the application and many of the files in your project
+directory have been symlinked inside it.
 
 **Notes and Known Issues**
 
 - You may see `SystemError: Parent module 'setuptools' not loaded, cannot perform relative import`
-  at the dependency locking step. This depends on your version of `setuptools` (bleeding edge causes this)
-  and can be solved by setting an environment variable: `SETUPTOOLS_USE_DISTUTILS=stdlib`. [See more details](https://github.com/pypa/setuptools/blob/17cb9d6bf249cefe653d3bdb712582409035a7db/CHANGES.rst#v5000). This sudden upstream change will be addressed more systematically in future releases.
+  at the dependency locking step. This depends on your version of
+  `setuptools` (bleeding edge causes this) and can be solved by setting an
+  environment variable: `SETUPTOOLS_USE_DISTUTILS=stdlib`.
+  [See more details](https://github.com/pypa/setuptools/blob/17cb9d6bf249cefe653d3bdb712582409035a7db/CHANGES.rst#v5000).
+  This sudden upstream change will be addressed more systematically in future releases.
 
 
 ## Setup the database, Elasticsearch, Redis and RabbitMQ
@@ -52,10 +65,10 @@ setup correctly and the containers running them will even restart upon a reboot
 of your machine. If you stop and restart those containers, your data will still
 be there. Upon running this command again, the initial setup is skipped.
 
-
 ``` bash
 invenio-cli services
 ```
+
 ``` console
 Making sure containers are up...
 Creating network "development-instance_default" with the default driver
@@ -86,6 +99,7 @@ you can use `--force` and nuke the content!
 ``` bash
 invenio-cli services --force
 ```
+
 ``` console
 Making sure containers are up...
 development-instance_mq_1 is up-to-date
@@ -109,25 +123,6 @@ Creating indexes...
 Putting templates...
 ```
 
-**Known issues**:
-
-The Elasticsearch container might crash due to lack of memory. One solution is to increase the maximum allowed allocation per process (See more [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/docker.html)). Solving this issue depends on your OS:
-
-On Linux, add the following to ``/etc/sysctl.conf`` on your local machine (host machine):
-
-```bash
-# Memory mapped max size set for ElasticSearch
-vm.max_map_count=262144
-```
-
-On macOS, do the following:
-
-```bash
-screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
-# and in the shell
-sysctl -w vm.max_map_count=262144
-```
-
 ## Populate DB
 
 Let's add some content so you can interact a bit with the instance. For this
@@ -136,6 +131,7 @@ you will generate 10 random demo records, using the `demo` command:
 ``` bash
 invenio-cli demo --local
 ```
+
 ``` console
 Making sure containers are up...
 development-instance_mq_1 is up-to-date

--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -15,6 +15,13 @@ the name used in the configurations for them, you won't even need to edit `inven
 
 No worries, we go through *all* of the common customizations below.
 
+!!! info "Using `--development` might save some time"
+    This is recommended for developers and advanced users only. Most of the change
+    below require a `invenio-cli assets update` call. However, if you create symbolic
+    links from the beggining and watch the CSS changes as described in the
+    [following section](./edit_a_module.md) most of the changes will be available
+    instantly.
+
 ## Change the logo
 
 Having your instance represent your institution starts with using your
@@ -27,10 +34,10 @@ We'll use the [invenio color logo](https://github.com/inveniosoftware/invenio-th
 cp ./path/to/new/color/logo.svg static/images/invenio-rdm.svg
 ```
 
-Then, use the `update` command:
+Then, use the `assets update` command:
 
 ``` bash
-invenio-cli update --no-install-js
+invenio-cli assets update
 ```
 ``` console
 # Summarized output
@@ -43,10 +50,8 @@ Building assets...
 Built webpack project.
 ```
 
-Passing the `--no-install-js` option, skips re-installation of JS dependencies.
-
 !!! info "Assets and statics need to be updated"
-    Whenever you change files in `assets/` or `static/`, you typically want to run `invenio-cli update --no-install-js`. In case of uncertainty, just run the `update` command; it isn't destructive.
+    Whenever you change files in `assets/` or `static/`, you typically want to run `invenio-cli assets update`. In case of uncertainty, just run the `update` command; it isn't destructive.
 
 In the browser, go to [https://127.0.0.1:5000/](https://127.0.0.1:5000) or refresh the page. And voilà! The logo has changed!
 
@@ -60,7 +65,7 @@ If your logo isn't an svg, you still copy it to `static/images/`, but you need t
 + THEME_LOGO="images/my-logo.png"
 ```
 
-You also need to run `update` as above and additionally restart the server:
+You also need to run `assets update` as above and additionally restart the server:
 
 ```bash
 ^C
@@ -68,7 +73,7 @@ Stopping server and worker...
 Server and worker stopped...
 ```
 ```bash
-invenio-cli update --no-install-js
+invenio-cli assets update
 invenio-cli run
 ```
 
@@ -76,7 +81,7 @@ invenio-cli run
     All changes to `invenio.cfg` **MUST** be accompanied by a restart like the above to be picked up. This only restarts the server; it does not destroy any data.
 
 All other changes below follow the same pattern: add files and/or edit `invenio.cfg` and
-potentially execute `update` and/or rerun the server.
+potentially execute `assets update` and/or rerun the server.
 
 
 ## Change the colors
@@ -90,7 +95,7 @@ We are going to change the top header section in the frontpage to apply our cust
 @navbar_background_color: #000000; // Note this hex value is an example. Choose yours.
 ```
 
-Then, run the `invenio-cli update --no-install-js` command as above and refresh the page! You should be able to see your top header's color changed! You can find all the available styling variables that you can change [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less).
+Then, run the `invenio-cli assets update` command as above and refresh the page! You should be able to see your top header's color changed! You can find all the available styling variables that you can change [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less).
 
 
 ## Change the search results
@@ -118,7 +123,7 @@ export function ResultsItemTemplate(record, index) {
 };
 ```
 
-Then, run the `invenio-cli update` command as above and refresh the page! You should be able to see more text in each result's description! You can find all the available templates [here](https://github.com/inveniosoftware/invenio-app-rdm/tree/master/invenio_app_rdm/theme/assets/templates/search).
+Then, run the `invenio-cli assets update` command as above and refresh the page! You should be able to see more text in each result's description! You can find all the available templates [here](https://github.com/inveniosoftware/invenio-app-rdm/tree/master/invenio_app_rdm/theme/assets/templates/search).
 
 
 ## Change the record landing page
@@ -467,8 +472,6 @@ we were.
 
 ## Add functionality
 
-Need further customizations or additional features? Have you thought of
-creating your own extensions?
-
-How to make an extension and add it to your InvenioRDM instance is explained in
-the [Extensions section](../extensions/custom.md).
+Need further customizations or additional features? If you are developing a
+features in an existing module check the [Develop or edit a module section](./edit_a_module.md).
+If you are creating your own extensions check the [Extensions section](../extensions/custom.md).

--- a/docs/develop/run.md
+++ b/docs/develop/run.md
@@ -3,9 +3,13 @@
 Once the application is installed locally and the services are running, our
 application just needs to run. For that, the `run` command is executed.
 
+This time you can avoid setting the `SITE_HOSTNAME` by using the `--host`
+and `--port` flags.
+
 ``` bash
-invenio-cli run
+invenio-cli run --host 127.0.0.1 --port 5000
 ```
+
 ``` console
 # Summarized output
 Making sure containers are up...
@@ -21,11 +25,12 @@ Are we done? Yes, let the fun begin...
 
 ### List records
 
-!!! warning "Use 127.0.0.1"
-    Due to CSP it is important that you use 127.0.0.1, and not localhost. Unless you set the `SERVER_HOSTNAME` to localhost.
+!!! warning "Use the specified host and port"
+    Due to CSP it is important that you use the host and port specified when
+    running the instance. This means, `localhost` and `127.0.0.1` are not
+    interchangable as usually. The default is `127.0.0.1:5000`.
 
 Let's see what is in the instance by querying the API. Using another terminal:
-
 
 ``` bash
 curl -k -XGET https://127.0.0.1:5000/api/records | python3 -m json.tool
@@ -363,6 +368,7 @@ And then search for it:
 ``` bash
 curl -k -XGET https://127.0.0.1:5000/api/records?q=Gladiator | python3 -m json.tool
 ```
+
 ``` json
 {
     "aggregations": {},
@@ -457,7 +463,6 @@ And visit the record page for the newly created record. You will see it has no f
 !!! error "Temporarily not supported"
     This is temporarily disabled until the new API is fully compatible with it.
 
-
 For demonstration purposes, we will attach this scientific photo:
 
 ![Very scientific picture of a shiba in the snow](https://images.unsplash.com/photo-1548116137-c9ac24e446c9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80)
@@ -474,3 +479,15 @@ curl -k -X PUT https://127.0.0.1:5000/api/records/jnmmp-51n47/files/snow_doge.jp
 ```
 
 This file can then be previewed on the record page and even downloaded.
+
+## Stop it
+
+If you want to temporarily stop the instance, without loosing the data that
+was generated you can use the `stop` command:
+
+```bash
+invenio-cli stop
+```
+
+Check the [Celanup section](./cleanup.md) if you wish to remove every
+reference to InvenioRDM from Docker (containers, images, networks, etc.).

--- a/docs/develop/troubleshoot.md
+++ b/docs/develop/troubleshoot.md
@@ -29,6 +29,7 @@ The most interesting ones will be the `web-ui` and `web-api` containers, which i
 ``` bash
 docker logs ff9a589845e4
 ```
+
 ``` console
 [uWSGI] getting INI configuration from /opt/invenio/var/instance/uwsgi_rest.ini
 *** Starting uWSGI 2.0.18 (64bit) on [Wed Jan  8 13:09:07 2020] ***

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -25,14 +25,43 @@ the docker command (i.e. it is not only available for the root user):
 sudo usermod --append --groups docker $USER
 ```
 
-!!! note "Hardware and Docker requirements"
-    We usually deploy the RDM in machines that have around 8GB of RAM and at least 4 cores. On the same topic, make sure that docker has enough memory to run. Be default it gets 2GB of RAM, which most likely won't be enough. If you can allocate 6-8GB to it might be optimal. In OS X you can do that in `Docker --> preferences --> resources --> advanced` and adjust the `Memory` to the corresponding value. If you have a few cores more to spare, it might be a good idea to give more than 2. Take into account that you are going to be running between 4 and 8 containers (among them an Elasticsearch container, which is quite demanding).
+#### Hardware and Docker requirements
 
-Once you have installed these requirements, you can install the CLI.
+We usually deploy the RDM in machines that have around 8GB of RAM and at least
+4 cores. On the same topic, make sure that docker has enough memory to run. Be
+default it gets 2GB of RAM, which most likely won't be enough. If you can
+allocate 6-8GB to it might be optimal. 
+
+In Linux based systems Docker can use all available memory. In OS X you can do
+that in `Docker --> preferences --> resources` and adjust the `Memory` to the
+corresponding value. If you have a few cores more to spare, it might be a good
+idea to give more than 2. Take into account that you are going to be running
+between 4 and 8 containers (among them an Elasticsearch container, which is
+quite demanding).
+
+In previous releases we recommended to increase the maximum allowed allocation
+per process (See more [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/docker.html)).
+However, it has been reported to not be working anymore.
+
+On Linux, add the following to ``/etc/sysctl.conf`` on your local machine (host machine):
+
+```bash
+# Memory mapped max size set for ElasticSearch
+vm.max_map_count=262144
+```
+
+On macOS, do the following:
+
+```bash
+screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+# and in the shell
+sysctl -w vm.max_map_count=262144
+```
 
 ## Install the CLI
 
-You can install and manage your InvenioRDM instance using the Invenio CLI package,
+Once you have installed these requirements, you can install the Invenio-CLI
+and manage your InvenioRDM instance using the Invenio CLI package,
 aptly named `invenio-cli`. The package is available on [PyPI](https://pypi.org/project/invenio-cli/).
 Use your favorite way to install a Python package:
 

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -101,7 +101,7 @@ drwxr-xr-x 3 youruser youruser 4096 Feb 19 13:45 static/
 drwxr-xr-x 2 youruser youruser 4096 Feb 19 13:45 templates/
 ```
 
-**Notes and Known Issues**
+#### Notes and Known Issues
 
 - For now, the only available flavour is RDM (Research Data Management). In the future, there will be others, for example ILS (Integrated Library System).
 
@@ -110,21 +110,39 @@ drwxr-xr-x 2 youruser youruser 4096 Feb 19 13:45 templates/
 - Some OpenSSL versions display an error message when obtaining random numbers, but this has no incidence (as far as we can tell) on functionality. We are investigating a possible solution to raise less eyebrows for appearance sake.
 
 
-## Containerize and run your instance
+## Preview instance
 
-!!! warning "NEW: Adjust `SERVER_HOSTNAME` in `invenio.cfg`"
-    New in the August release: change `SERVER_HOSTNAME` in `invenio.cfg` as below.
+!!! warning "NEW: Adjust `SITE_HOSTNAME`"
+    New in the November release the `SERVER_HOSTNAME` is now called `SITE_HOSTNAME` and can be modified in `invenio.cfg` or using environment variables.
+
+#### Set SITE_HOSTNAME
+
+This is required because `invenio-cli init rdm` generates a config file (`invenio.cfg`)
+for [development usage](../develop/index.md) by default. We need to tweak it,
+because we are only previewing InvenioRDM.
 
 Before running your instance, change the following in `invenio.cfg`:
 
 ```diff
-- SERVER_HOSTNAME = "127.0.0.1:5000"
-+ SERVER_HOSTNAME = "127.0.0.1"
+- SITE_HOSTNAME = "127.0.0.1:5000"
++ SITE_HOSTNAME = "127.0.0.1"
 ```
 
-This is because `invenio-cli init rdm` generates a config file (`invenio.cfg`)
-for [development usage](../develop/index.md) by default. We need to tweak it,
-because we are only previewing InvenioRDM.
+Alernatively, you can export it in your environment. If you do so, remember to prefix it with `INVENIO_`.
+
+Using a bash shell:
+
+```bash
+export INVENIO_SITE_HOSTNAME="127.0.0.1"
+```
+
+Using a fish shell:
+
+```fish
+set --export INVENIO_SITE_HOSTNAME "127.0.0.1"
+```
+
+#### Containerize and run
 
 The project is initialized, we now run it. Switch to the project
 directory and do so:
@@ -143,9 +161,9 @@ firefox https://127.0.0.1
 ```
 
 !!! warning "Use 127.0.0.1"
-    Due to CSP it is important that you use 127.0.0.1, and not localhost. Unless you set the `SERVER_HOSTNAME` to localhost.
+    Due to CSP it is important that you use 127.0.0.1, and not localhost. Unless you set the `SITE_HOSTNAME` to localhost.
 
-**Notes and Known Issues**
+#### Notes and Known Issues
 
 - You may see the following error message `TypeError: Object.fromEntries is not a function`.
   This means you need to update your base Invenio docker image because Node.js 14+ is needed.
@@ -181,6 +199,22 @@ invenio <your command>
 
 You can use `docker ps` to get the name or id of the web-api or web-ui container.
 
+## Stop it
+
+If you want to temporarily stop the instance, without loosing the data that
+was generated you can use the `stop` command:
+
+```bash
+invenio-cli stop
+```
+
+On the other hand, if you wish clean up and delete every Docker trace
+InvenioRDM you can use the `destroy` command. Note that `destroy` will
+also `stop` the containers, so there is no need to run the previous command:
+
+```bash
+invenio-cli destroy
+```
 
 ## Conclusions
 
@@ -189,8 +223,9 @@ In just two commands you can get a preview of InvenioRDM:
 ``` bash
 invenio-cli init rdm
 cd <project name>
-# Set SERVER_HOSTNAME = "127.0.0.1" in invenio.cfg
+# Export INVENIO_SITE_HOSTNAME = "127.0.0.1" or set it in invenio.cfg
 invenio-cli containerize --pre
+invenio-cli stop
 ```
 
 These instructions don't provide you with a nice development experience though.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Install Locally: 'develop/install_locally.md'
     - Run: 'develop/run.md'
     - Make it your own: 'develop/make_it_your_own.md'
+    - Develop/Edit a module: 'develop/edit_module.md'
     - Troubleshooting: 'develop/troubleshoot.md'
     - Cleanup: 'develop/cleanup.md'
   - Extensions:


### PR DESCRIPTION
Closes #76 

Changes:

- Move all docker hardware allocation notes to pre-requisites
- Migrate `SERVER_HOSTNAME` to `SITE_HOSTNAME`. Instruct the use of `--host` and `--port` for `invenio-cli run`.
- Remove the need to export `FLASK_ENV`, use `--development/-d` flag
- Change `Notes and Known Issues` sections from bold to h4 (still displays equally), but allows sending it as link (which is helpful when sending info to partners when troubleshooting/testing).
- Reference `stop` command, remove `--local/--containers` flags from `destroy` command.
- Migrates any reference to the old `invenio-cli update [--no-install-js]` command to the new `invenio-cli assets update [--force]`.

**Adds**:
- A new section `develop/edit_module.md` to explain how to setup and develop CSS and React.