### PR TITLE
docs: update RDM_RECORDS_CUSTOM_VOCABULARIES dictionary

### DIFF
--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -179,9 +179,11 @@ from os.path import abspath, dirname, join
 # At the bottom
 # Our custom Vocabularies
 RDM_RECORDS_CUSTOM_VOCABULARIES = {
-    'resource_types': join(
-        dirname(abspath(__file__)),
-        'app_data', 'vocabularies', 'resource_types.csv')
+    'resource_type': {
+        'path': join(
+            dirname(abspath(__file__)),
+            'app_data', 'vocabularies', 'resource_types.csv')
+    }
 }
 ```
 


### PR DESCRIPTION
In the section [Define a custom controlled vocabulary](https://inveniordm.docs.cern.ch/develop/make_it_your_own/#extend-the-metadata-model), should the dictionary structure be updated?

```
RDM_RECORDS_CUSTOM_VOCABULARIES = {
    'resource_type': {
        'path': join(
            dirname(abspath(__file__)),
            'app_data', 'vocabularies', 'resource_types.csv')
    }
}
```
With a fresh installation with `invenio-cli 0.18.0` and `invenio-rdm-records` 0.23.10, I followed [the structure from config.py](https://github.com/inveniosoftware/invenio-rdm-records/blob/f6b38b640a35e1ac496e443b6b25c1d13f3ca575/invenio_rdm_records/config.py#L209):
* replace `resource_types` by `resource_type`
* add a nested key named  `path`