### PR TITLE
Fixes permission code-example.

### DIFF
--- a/docs/develop/make_it_your_own.md
+++ b/docs/develop/make_it_your_own.md
@@ -318,8 +318,8 @@ Open `invenio.cfg` in your favorite text editor (or least favorite if you
 like to suffer) and add the following to the file:
 
 ```python
-from invenio_rdm_records.services import BibliographicRecordServiceConfig, \
-    RDMRecordPermissionPolicy
+from invenio_rdm_records.services import RDMRecordPermissionPolicy
+from invenio_rdm_records.services.config import RDMRecordServiceConfig
 from invenio_records_permissions.generators import SuperUser
 
 
@@ -327,7 +327,7 @@ class MyRecordPermissionPolicy(RDMRecordPermissionPolicy):
     can_create = [SuperUser()]
 
 
-class MyBibliographicRecordServiceConfig(BibliographicRecordServiceConfig):
+class MyBibliographicRecordServiceConfig(RDMRecordServiceConfig):
     permission_policy_cls = MyRecordPermissionPolicy
 
 


### PR DESCRIPTION
Within the last releases `BibliographicRecordServiceConfig` was renamed
to `RDMRecordServiceConfig` (and moved?). Adjusting the import and name
makes it work again.

Refs https://github.com/inveniosoftware/docs-invenio-rdm/issues/116