### PR TITLE
Remove mentions of virtual environments

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -29,8 +29,7 @@ things can go wrong, so the added time is worth it.
 In addition, if you want to modify CSS and see it when reloading the page you
 need to *watch* the assets. This will automatically rebuild the webpack bundles
 when you change the CSS (`.less`) files. In order to watch them, open another
-terminal (still in your instance path i.e. `development-instance/`)
-and activate the same virtual environment. Then run:
+terminal (still in your instance path i.e. `development-instance/`). Then run:
 
 ```
 invenio-cli assets watch
@@ -63,8 +62,7 @@ invenio-cli assets install /path/to/react-module
 ```
 
 Then you have to watch it. Open another terminal in your instance path
-(`development-instance/` as before) and activate the same
-virtual environment. Note that if you are already watching some python
+(`development-instance/` as before). Note that if you are already watching some python
 module, this action is independent (and per module):
 
 ```


### PR DESCRIPTION
In the suggested workflow, there's no need to activate a virtual environment when developing on the CSS/templates (e.g. `invenio-app-drm`) or on the react modules. It can create confusion to tell people to activate a virtualenv when it was never mentioned to create one in the first place (as opposed to the workflow for separate modules, e.g. invenio-cli itself).

The tested flow:

```
pip install invenio-cli
invenio-cli check-requirements --development
invenio-cli init rdm

cd my-site/
invenio-cli install
invenio-cli services setup
invenio-cli run

# in another shell, but in the same instance directory (i.e. my-site)
invenio-cli packages install invenio-app-rdm
invenio-cli assets watch

# you can now edit e.g. 
# invenio-app-drm/invenio-app--drm/theme/templated/semantic-ui/invenio_app_drm/frontpage.html 
# and see the modifications live

```