### PR TITLE
Adjusts documentation

### DIFF
--- a/docs/customize/vocabularies/users.md
+++ b/docs/customize/vocabularies/users.md
@@ -3,17 +3,17 @@
 Users are not a vocabulary *per se*, but they are loaded in the same fashion,
 through the application data folder.
 
-This file contains a list of users to create, and is stored in the root of the
-`app_data` folder.
+The file `users.yaml` contains a list of users to create, and is stored in the
+root of the `app_data` folder.
 
 ```
 app_data/
 └── users.yaml
 ```
 
-If the file is provided but it is empty, no default user is created. If the
-file is not provided, InvenioRDM creates an admin user with email
-`admin@inveniosoftware.org` (and a random password).
+If the file is not provided, InvenioRDM creates an admin user with the email
+`admin@inveniosoftware.org` (and a random password). If the file is provided
+but it is empty, no default user is created.
 
 The content of the file is as follows:
 
@@ -30,7 +30,3 @@ The content of the file is as follows:
 - `password` : Their password. If empty, a random one is generated.
 - `roles` : Array of roles the user has. The roles must already be present in the DB.
 - `allow` : Array of action needs the user has.
-
-InvenioRDM creates a default admin user with an inveniosoftware.org email; you
-probably want to change that too. In this section, we outline how to customize
-the data your instance uses.

--- a/docs/customize/vocabularies/users.md
+++ b/docs/customize/vocabularies/users.md
@@ -11,10 +11,6 @@ app_data/
 └── users.yaml
 ```
 
-If the file is not provided, InvenioRDM creates an admin user with the email
-`admin@inveniosoftware.org` (and a random password). If the file is provided
-but it is empty, no default user is created.
-
 The content of the file is as follows:
 
 ```yaml
@@ -30,3 +26,7 @@ The content of the file is as follows:
 - `password` : Their password. If empty, a random one is generated.
 - `roles` : Array of roles the user has. The roles must already be present in the DB.
 - `allow` : Array of action needs the user has.
+
+If the file is not provided, InvenioRDM creates an admin user with the email
+`admin@inveniosoftware.org` (and a random password). If the file is provided
+but is empty, no default user is created.


### PR DESCRIPTION
- Makes reference 'this file' which wasn't named before explicit.
- Switches two sentences to improve reading flow.
- Removes sentence that seems out of place (at the bottom of the file) and seems to be doubled with a sentence before.