### PR TITLE
Updates documentation wrt. fix in cookiecutter

### DIFF
--- a/docs/customize/styling-theme.md
+++ b/docs/customize/styling-theme.md
@@ -4,10 +4,10 @@ You might also be wondering: *How do I change the colors so I can make my instan
 
 The theme comprises the header, footer and main color(s). We are going to modify them. It's a good example of the workflow for when `assets/` files change.
 
-Open the `assets/less/site/globals/site.overrides` file and edit it to have the following:
+Open the `assets/less/site/globals/site.variables` file and edit it to have the following:
 
 ``` less
-@import "@less/invenio_app_rdm/theme";
+@import "@less/invenio_app_rdm/variables";
 
 @brandColor: /* your brand color here */ ;
 
@@ -24,9 +24,9 @@ Open the `assets/less/site/globals/site.overrides` file and edit it to have the 
 
 Then, run the `invenio-cli assets build -d` command as above and refresh the page! You should be able to see your theme color(s)!
 
-You can override any styling variables in your `site.overrides` file. The available styling variables are found in the `variables.less` or `.variables` files of the various invenio modules installed. The ones above are originally defined [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less). The `invenio-theme` module defines a large number of them [here](https://github.com/inveniosoftware/invenio-theme/tree/master/invenio_theme/assets/semantic-ui/less/invenio_theme/theme).
+You can override any styling variables in your `site.variables` file. The available styling variables are found in the `variables.less` or `.variables` files of the various invenio modules installed. The ones above are originally defined [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less). The `invenio-theme` module defines a large number of them [here](https://github.com/inveniosoftware/invenio-theme/tree/master/invenio_theme/assets/semantic-ui/less/invenio_theme/theme).
 
-However, you may notice further changes to the `site.overrides` file are not picked up unless `invenio-cli assets build` is run again each time even though we symlinked these files! That's because `.less` files (and javascript files below) always need to be transformed into their final form first. `invenio-cli assets build` does that. There is a way to get the same workflow as `static/` files, without having to re-run that command over and over: run `invenio-cli assets watch`. It watches for changes to assets and rebuilds them automatically.
+However, you may notice further changes to the `site.variables` file are not picked up unless `invenio-cli assets build` is run again each time even though we symlinked these files! That's because `.less` files (and javascript files below) always need to be transformed into their final form first. `invenio-cli assets build` does that. There is a way to get the same workflow as `static/` files, without having to re-run that command over and over: run `invenio-cli assets watch`. It watches for changes to assets and rebuilds them automatically.
 
 The workflow for `assets/` files is then:
 


### PR DESCRIPTION
Fix in cookiecutter: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/201
Note: You can do all these variable-overwrites also in the overrides files, but I think it is conceptually wrong: https://semantic-ui.com/usage/theming.html#theme-files see "Composing a Component" difference 'variables' and 'overrides'
In 'variables' you could also change

```
@blue: @brandColor;
```
Which is not working if you put it in overrides.

If this patch is not accepted and the variable-overwrites should go in overrides then the documentation would need the following alternative adjustment:

``` less
@import "@less/invenio_app_rdm/variables";
@import "site.variables";

@brandColor: /* your brand color here */ ;

@navbar_background_image: unset;
@navbar_background_color: @brandColor;
@footerLightColor: @brandColor;
@footerDarkColor: /* a shade of your brandColor */;
```
Currently we 'overwrite' the added fix in cookiecutter (`@import "site.variables";`) in the documentation.