### PR TITLE
Customize: updated users.yaml format

### DIFF
--- a/docs/customize/vocabularies/users.md
+++ b/docs/customize/vocabularies/users.md
@@ -14,14 +14,15 @@ app_data/
 The content of the file is as follows:
 
 ```yaml
-<email>:
-  active: <bool>
-  password: <string>
-  roles: <array of strings>
-  allow: <array of strings>
+#list of users:
+-  email: <string>
+   active: <bool>
+   password: <string>
+   roles: <array of strings>
+   allow: <array of strings>
 ```
 
-- `<email>` : Email of the user.
+- `email` : Email of the user.
 - `active` : Is the user active or not.
 - `password` : Their password. If empty, a random one is generated.
 - `roles` : Array of roles the user has. The roles must already be present in the DB.


### PR DESCRIPTION
The format of the users.yaml file seems to be different from what is expected in the code, correct me if i am wrong. It is also not clear, from first sight, that the example is a singular item that has to be inside a *list*