### PR TITLE
Improve the documentation of the styling.

### DIFF
--- a/docs/customize/styling-logo.md
+++ b/docs/customize/styling-logo.md
@@ -1,63 +1,47 @@
 # Change the logo
 
-Having your instance represent your institution starts with using your
-institution's logo. We are going to change InvenioRDM's default logo to your logo.
+Having your instance represent your institution starts with using your institution's logo. We are going to change InvenioRDM's default logo to your logo.
+There are two ways to achieve this goal: first you can just replace the current logo file by your logo, alternatively, you can modify the configuration to use a different file.
 
-Take an *svg* file and copy it to your **local** static files.
-We'll use the [invenio white logo](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/static/images/logo-invenio-white.svg) as an example:
+## Replace the current logo file
+
+The default configuration uses as the website logo the file `static/images/invenio-rdm.svg` of your local installation. If you wish to change the logo of the page, you must replace that file with by your own logo. Ensure that your logo file has the same file extension (*svg*).
 
 ``` bash
 cp static/images/logo-invenio-white.svg static/images/invenio-rdm.svg
 ```
 
-Then, use the `assets build` command:
+After replacing the logo file, you need to use the `assets build` command:
 
 ``` bash
 invenio-cli assets build
 ```
-``` console
-# Summarized output
-Collecting statics and assets...
-Collect static from blueprints.
-Created webpack project.
-Copying project statics and assets...
-Symlinking assets/...
-Building assets...
-Built webpack project.
-```
 
-This command makes sure files you have in `static/`, `assets/`, `templates/` and so on are placed in the right location with other similar files for the application. The files are by default symlinked to ensure future modifications to those files translate directly. No need to run `invenio-cli assets build` again for them.
+This command makes sure files you have in `static/`, `assets/`, `templates/` and so on are placed in the right location with other similar files for the application. 
 
-In the browser, go to [https://127.0.0.1:5000/](https://127.0.0.1:5000) or refresh the page. And voilà! The logo has changed!
+Once the `assets build` command has finished running you can reload your InvenioRDM website (or access it for the first time) to check that page logo has changed to your custom log.
 
 !!! warning "That evil cache"
     If you do not see it changing, check in an incognito window; the browser might have cached the logo.
 
-If your logo isn't an svg, you still copy it to `static/images/`, but you need to edit the `invenio.cfg` file appropriately:
+## Change the configuration
+
+If your wish to use a logo file with a different name (for example, because the logo file isn't an *svg*) you will need first to copy your file in the `static/images/` of your local installation and then edit your `invenio.cfg` file appropriately:
 
 ```diff
-- THEME_LOGO="images/logo.svg"
-+ THEME_LOGO="images/my-logo.png"
+- THEME_LOGO = 'images/invenio-rdm.svg'
++ THEME_LOGO = 'images/your-logo-filename.extension'
 ```
 
-Then, run `assets build` as above and additionally restart the server:
-
-```bash
-^C
-Stopping server and worker...
-Server and worker stopped...
+For the new file to be taken into account you must, as explained before, run the `assets build`.
+``` bash
+invenio-cli assets build
 ```
+
+Aditionally, once you modify the configuration of the application, you have to stop and restart the server. For stopping the server you just have to go to the terminal in which your server is running and press `Ctrl + C`. No data will be lost by this action. After stopping the server, you just need to run it again.
 ```bash
-invenio-cli assets build -d
 invenio-cli run
 ```
+After this steps, you can reload your InvenioRDM site to check that the logo has changed.
 
-!!! info "Re-run when invenio.cfg changes"
-    All changes to `invenio.cfg` **MUST** be accompanied by a restart like the above to be picked up. This only restarts the server; it does not destroy any data.
-
-This workflow stands for all `static/` files:
-
-- If you add a new file, run `invenio-cli assets build -d`.
-- If you modify `invenio.cfg`, re-run `invenio-cli run` (because `invenio.cfg` has been symlinked above, you don't need to run `assets build`).
-- If you modify a previously symlinked file, you don't need to do anything.
 


### PR DESCRIPTION
This attempt to improve the documentation of the styling tried to implement the following feedback to the documentation:

- In my opinion, we should define a clear separation between replacing the logo directly in the assets folder and defining a different configuration. I would also explain better that in the first case we are just replacing the logo file with another with the same name, while in the second we are setting which file the application will use as logo. 
- The page doesn’t support any logo resolution. Shouldn’t we specify the allowed resolutions in the doc?
- In the box displaying the change of the logo in the invenio.cfg. I would change the remove text part to fit what we currently have (```- THEME_LOGO="images/logo.svg"``` for ```- THEME_LOGO = 'images/invenio-rdm.svg'```). I would also replace ^C by Ctrl + C.
- As far as I understand reading the doc, if a file is symlinked, any change I do to the file should be reflected, but it doesn’t seem to be the case.
- As said before, I would do a small refactor on how the information is structured.
