### PR TITLE
reference: fix description and punctuation in overview

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,7 +6,7 @@ These guides are intended for advanced users, administrators and developers that
 
 ## Guides
 
-- **[CLI](cli.md)**: A reference guide for all the REST APIs that InvenioRDM exposes
+- **[CLI](cli.md)**: A reference guide to the commands provided by the Invenio-CLI tool.
 - **[Configuration](configuration)**: A reference guide for the configuration variables in InvenioRDM.
 - **[Metadata Reference](metadata.md)**: A reference guide for the internal metadata schema of bibliographic records in InvenioRDM.
 - **[OAI-PMH](oai_pmh.md)**: A reference guide for the OAI-PMH functionality which InvenioRDM exposes

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,5 +9,5 @@ These guides are intended for advanced users, administrators and developers that
 - **[CLI](cli.md)**: A reference guide to the commands provided by the Invenio-CLI tool.
 - **[Configuration](configuration)**: A reference guide for the configuration variables in InvenioRDM.
 - **[Metadata Reference](metadata.md)**: A reference guide for the internal metadata schema of bibliographic records in InvenioRDM.
-- **[OAI-PMH](oai_pmh.md)**: A reference guide for the OAI-PMH functionality which InvenioRDM exposes
-- **[REST API](rest_api_index.md)**: A reference guide for all the REST APIs that InvenioRDM exposes
+- **[OAI-PMH](oai_pmh.md)**: A reference guide for the OAI-PMH functionality which InvenioRDM exposes.
+- **[REST API](rest_api_index.md)**: A reference guide for all the REST APIs that InvenioRDM exposes.


### PR DESCRIPTION
Contains some fixes in the [overview](https://github.com/inveniosoftware/docs-invenio-rdm/blob/c7929894a2fa77a0672a0fff9e0288a7b92b10af/docs/reference/index.md) of the reference documentation:
- Fixed the description of the CLI section, which incorrectly referred to the REST API reference guide. The new description was copied from the [CLI reference guide](https://github.com/inveniosoftware/docs-invenio-rdm/blob/c7929894a2fa77a0672a0fff9e0288a7b92b10af/docs/reference/cli.md?plain=1#L5).
- Fixed some minor punctuation inconsistencies.