### PR TITLE
vocabularies: contrib should not need to specify service twice

### DIFF
--- a/docs/customize/vocabularies/funding.md
+++ b/docs/customize/vocabularies/funding.md
@@ -64,12 +64,9 @@ funders:
   readers:
     - type: yaml
       args:
-          origin: "app_data/vocabularies/funders.yaml"
+        origin: "app_data/vocabularies/funders.yaml"
   writers:
     - type: funders-service
-      args:
-        service_or_name: funders
-        identity: system_identity
 ```
 
 To run the actual import using this `vocabularies-future.yaml` file you can call the `vocabularies import` command, if you don't pass origin arg in `vocabularies-future.yaml` you can pass your YAML file containing the funder records via the `--origin` parameter:
@@ -157,12 +154,9 @@ awards:
   readers:
     - type: yaml
       args:
-          origin: "app_data/vocabularies/awards.yaml"
+        origin: "app_data/vocabularies/awards.yaml"
   writers:
     - type: awards-service
-      args:
-        service_or_name: awards
-        identity: system_identity
 ```
 
 To run the actual import using this `vocabularies-future.yaml` file you can call the `vocabularies import` command , if you don't pass origin arg in `vocabularies-future.yaml` you can pass your YAML file containing the award records via the `--origin` parameter:

--- a/docs/customize/vocabularies/names.md
+++ b/docs/customize/vocabularies/names.md
@@ -38,8 +38,8 @@ A _Name_ record contains:
 
 ### How to import and update your name records
 
-InvenioRDM ships with an example set of names and ORCID identifiers. 
-To disable these from being loaded, create a blank file called 
+InvenioRDM ships with an example set of names and ORCID identifiers.
+To disable these from being loaded, create a blank file called
 `app_data/vocabularies/names_orcid.yaml`.
 
 The Names vocabulary uses the new DataStreams API for processing vocabularies.
@@ -68,10 +68,7 @@ names:
       args:
         origin: "./app_data/names.yaml"
   writers:
-    - type: service
-      args:
-        service_or_name: names
-        identity: system_identity
+    - type: names-service
 ```
 
 Finally, to run an **import** using this `vocabularies-future.yaml` file you


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-vocabularies/pull/203
- partly closes #384 

by not setting the service name, it had to be stated twice in the yaml file.

Before:

```yaml
writers:
    - type: funders-service
      args:
        service_or_name: funders
        identity: system_identity
```

Now

```yaml
writers:
    - type: funders-service
      args:
        identity: system_identity
```