### PR TITLE
fix keycloak example configuration

### DIFF
--- a/docs/customize/authentication.md
+++ b/docs/customize/authentication.md
@@ -115,6 +115,7 @@ helper = KeycloakSettingsHelper(
     realm="my-realm"
 )
 
+SECURITY_LOGIN_WITHOUT_CONFIRMATION = True  # don't require users to confirm email before being able to login
 OAUTHCLIENT_KEYCLOAK_REALM_URL = helper.realm_url
 OAUTHCLIENT_KEYCLOAK_USER_INFO_URL = helper.user_info_url
 OAUTHCLIENT_KEYCLOAK_VERIFY_EXP = True  # whether to verify the expiration date of tokens


### PR DESCRIPTION
### Description
added the line `SECURITY_LOGIN_WITHOUT_CONFIRMATION = True` to the example keycloak configuration.

I noticed that without this option, invenio and keycloak are stuck in a redirection loop after providing credentials.

