### PR TITLE
Mention how to create an (administrator) account

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -82,6 +82,13 @@ Go and explore your InvenioRDM instance on:
 
     All major browsers allow you to bypass the warning (not easily though). In Chrome/Edge you have to click in the browser window and type ``thisisunsafe``.
 
+To create a new administrator account:
+
+- `invenio users create <EMAIL> --password <PASSWORD>`
+- Activate it with `invenio users activate <EMAIL>`
+- If you have email verification enabled (as per defaults) you may want to [verifiy the account manually](https://inveniordm.docs.cern.ch/customize/vocabularies/users/#confirm-user)
+- Allow the user to access the administration panel: `invenio access allow administration-access user <EMAIL>`
+
 #### [6. Stop it](destroy.md)
 
 When you are done, you can stop your instance and optionally destroy the containers:


### PR DESCRIPTION
This PR aims to provide a basic reference point for creating an account and giving it administrator privileges.

Some points I think they should be discussed (optionally outside of the scope of this):

- It's very confusing to have "invenio" and "inveino-cli" commands in the quickstart guide for trying-out InvenioRDM locally. I think the two need to be introduced (or at least disambiguated)
- It still feels a bit out of context to talk about this in the QuickStart deploy locally instructions, I think this may be better fitted in Use of Configure, if a new section can be created there for this
- Make the usage of "User" and "Account" terms more consistent, as it can lead to confusion
- Add a new section for the User Management (why is it in Vocabularies? it feels like very specific to the "invenio-way", which I may not know about if I'm just trying it out..). The recipe for giving the administrator access is mentioned without context in a migration guide only.