### PR TITLE
Fix access requirements

### DIFF
--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -231,7 +231,8 @@ Example:
 }
 ```
 
-The `access` field is required by the REST API.
+The `access` field will default to `public` for both records and files if not
+provided to the REST API.
 
 ## Metadata
 

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -231,7 +231,7 @@ Example:
 }
 ```
 
-The `access` field will default to `public` for both records and files if not
+The `access` field will default to `"public"` for both `record` and `files` fields if not
 provided to the REST API.
 
 ## Metadata


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The metadata document indicates that the `access` field is required, but that's not accurate. The REST API is perfectly happy to create a record with public access if `access` is not provided.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
