### PR TITLE
Fix typo in develop/architecture/records.md

### DIFF
--- a/docs/develop/architecture/records.md
+++ b/docs/develop/architecture/records.md
@@ -96,7 +96,7 @@ removed when they are either published or deleted/discarded.
 Every time a record is created or updated a copy of record is written as a
 record revision. The changes are only tracked on the record versions and only
 happens when a draft is published. This ensures that it is only published
-changes which a tracked.
+changes which are tracked.
 
 ### Version state
 

--- a/docs/develop/architecture/records.md
+++ b/docs/develop/architecture/records.md
@@ -93,10 +93,10 @@ removed when they are either published or deleted/discarded.
 
 ### Record (version) revision
 
-Every time a record is created or updated a copy of record is written as a
-record revision. The changes are only tracked on the record versions and only
-happens when a draft is published. This ensures that it is only published
-changes which are tracked.
+Every time a record is created or updated, a copy of the record is written as
+a _record revision_. The revisions are tracked per record version and only
+when the corresponding version draft is published. This ensures that only
+published changes are tracked.
 
 ### Version state
 


### PR DESCRIPTION
### Description

"only published changes which a tracked" should be "which are tracked".

I think the word "happens" in the sentence before this could also be removed but maybe I just don't understand it.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
