### PR TITLE
i18n: Clarify absolute paths in .po and .pot files

### DIFF
--- a/docs/develop/howtos/i18n.md
+++ b/docs/develop/howtos/i18n.md
@@ -375,6 +375,9 @@ Running this command will generate the corresponding `.pot` file:
  |- messages.pot
 ```
 
+!!! note "Absolute Paths in Localization Files"
+    Absolute paths in `messages.po` and `messages.pot` are comments for human reading context. They don't affect the compiled `.mo` file or app behavior.
+
 #### Initialize a message catalog for a locale
 
 The second step is to initialize the catalog for the specific locale of your choice.


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR adds a note to the documentation to clarify the role of absolute paths in .po and .pot localization files.
Users may be confused about the presence of absolute paths in these files. The note explains that these paths serve as comments for human context and do not impact the compiled .mo file or the application's behavior.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
