### PR TITLE
clarify empty rest api page

### DIFF
--- a/docs/develop/topics/rest.md
+++ b/docs/develop/topics/rest.md
@@ -1,3 +1,5 @@
 # REST API
 
-##...
+This section will contain information about how to develop REST API functionality.
+
+Reference documentation about the InvenioRDM REST API can be found [here](../../reference/rest_api_index). 

--- a/docs/develop/topics/rest.md
+++ b/docs/develop/topics/rest.md
@@ -1,5 +1,0 @@
-# REST API
-
-This section will contain information about how to develop REST API functionality.
-
-Reference documentation about the InvenioRDM REST API can be found [here](../../reference/rest_api_index.md). 

--- a/docs/develop/topics/rest.md
+++ b/docs/develop/topics/rest.md
@@ -2,4 +2,4 @@
 
 This section will contain information about how to develop REST API functionality.
 
-Reference documentation about the InvenioRDM REST API can be found [here](../../reference/rest_api_index). 
+Reference documentation about the InvenioRDM REST API can be found [here](../../reference/rest_api_index.md). 


### PR DESCRIPTION
minor fix, when searching the documentation page for "rest api" the result is the develop rest api page which is empty whereas most will be looking for the reference page

also, and more alarming, when searching for "rest api" the reference for rest api is NOT among results