### PR TITLE
Pass CI / Upgrade mkdocs-material

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -46,7 +46,7 @@ articles, and such.
 
 InvenioRDM is used all over the world, but not yet translated to all languages.
 You can make InvenioRDM even more accessible by joining the translation team
-and helping with translations. Follow the guide [here](translators-guide).
+and helping with translations. Follow the guide [here](translators-guide.md).
 
 ### Submit Feedback
 

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -7,7 +7,7 @@ when planning how to deploy InvenioRDM.
     This section assumes you have a good understanding of the different
     services that are needed to run an InvenioRDM application, and how they
     interact with each other. This information can be found in the
-    [infrastructure architecture](../develop/architecture/infrastructure/).
+    [infrastructure architecture](../develop/architecture/infrastructure.md).
 
 ## Deployment models
 
@@ -181,4 +181,4 @@ If the problem is in the InvenioRDM Python application, you can get more details
 in Sentry. Afterwards, you can try to reproduce it and debug in a local
 installation.
 
-For more information see the [how to debug section](../develop/getting-started/debugging/).
+For more information see the [how to debug section](../develop/getting-started/debugging.md).

--- a/docs/develop/howtos/custom_fields.md
+++ b/docs/develop/howtos/custom_fields.md
@@ -2,7 +2,7 @@
 
 *Introduced in InvenioRDM v10*
 
-This guide describes how to create your own custom field. If you have not done it yet, please read first about configuring [records custom fields](../../../customize/metadata/custom_fields/records).
+This guide describes how to create your own custom field. If you have not done it yet, please read first about configuring [records custom fields](../../customize/metadata/custom_fields/records.md).
 The new custom field in this example will extend the use case described in the records custom field documentation:
 
 _When uploading a research preprint at CERN, I want to record the title and the research program of the related CERN experiments._

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -32,8 +32,8 @@ You'll find the latest released version number on [PyPi](https://pypi.org/projec
 
 ### Commands reference
 
-For a full reference of available commands, see the [CLI reference](/reference/cli/)
+For a full reference of available commands, see the [CLI reference](../reference/cli.md)
 
 
 !!! tip "Shell tab completion"
-     Invenio-CLI has support for Shell tab completion of commands. See [Shell completion](/reference/cli/#shell-completion).
+     Invenio-CLI has support for Shell tab completion of commands. See [Shell completion](../reference/cli.md#shell-completion).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,7 +7,7 @@ These guides are intended for advanced users, administrators and developers that
 ## Guides
 
 - **[CLI](cli.md)**: A reference guide to the commands provided by the Invenio-CLI tool.
-- **[Configuration](configuration)**: A reference guide for the configuration variables in InvenioRDM.
+- **[Configuration](configuration.md)**: A reference guide for the configuration variables in InvenioRDM.
 - **[Metadata Reference](metadata.md)**: A reference guide for the internal metadata schema of bibliographic records in InvenioRDM.
 - **[OAI-PMH](oai_pmh.md)**: A reference guide for the OAI-PMH functionality which InvenioRDM exposes.
 - **[REST API](rest_api_index.md)**: A reference guide for all the REST APIs that InvenioRDM exposes.

--- a/docs/releases/upgrading/upgrade-v3.0.md
+++ b/docs/releases/upgrading/upgrade-v3.0.md
@@ -15,7 +15,7 @@ If unsure, run `invenio-cli install` from inside the instance directory before e
 !!! warning "Upgrade from v1 to v2"
 
     If you are upgrading an instance, that you previously upgrade from v1, please
-    check the [troubleshooting section](/releases/upgrading/upgrade-v2.0/#troubleshooting) for
+    check the [troubleshooting section](upgrade-v2.0.md#troubleshooting) for
     errors that were discovered in the v1 to v2 upgrade.
 
 ## Upgrade Steps

--- a/docs/releases/upgrading/upgrade-v6.0.md
+++ b/docs/releases/upgrading/upgrade-v6.0.md
@@ -19,7 +19,7 @@ migration may complain about missing packages.
 !!! warning upgrade your invenio-cli
 
     Make sure you have the latest invenio-cli, for InvenioRDM v6 release is v1.0.0
-    
+
 ### Upgrade your instance dependencies
 
 Bump the RDM version and rebuild the assets:
@@ -99,14 +99,14 @@ This script will check that your creators and contributors affiliations are
 either free text, which will require no action on your side, contain a ROR
 identifier or that they should be a custom vocabulary.
 
-If the affiliations contain ROR identifiers, you will need to add that 
-vocabulary. See more details [here](../../../customize/vocabularies/affiliations/). Otherwise, you will need to create a
+If the affiliations contain ROR identifiers, you will need to add that
+vocabulary. See more details [here](../../customize/vocabularies/affiliations.md). Otherwise, you will need to create a
 custom vocabulary in a similar fashion that was done for the subjects above,
 or fix your records (remove the identifiers so only the name is preserved).
 
 ### Prepare ES
 
-Once the vocabularies have been checked for compatibility and fixed 
+Once the vocabularies have been checked for compatibility and fixed
 accordingly, they need to be created:
 
 ```bash

--- a/docs/releases/versions/version-v3.0.0.md
+++ b/docs/releases/versions/version-v3.0.0.md
@@ -45,7 +45,7 @@ The backend works not only for DOIs but for any other external or internal persi
 
 **Using the new feature**
 
-Check the [documentation](/customize/dois/) to see how to enable and configure the feature. Note that you'll need a testing account with DataCite to complete this. If you don't have that, you can check the demo site, where we have the DOI feature enabled.
+Check the [documentation](../../customize/dois.md) to see how to enable and configure the feature. Note that you'll need a testing account with DataCite to complete this. If you don't have that, you can check the demo site, where we have the DOI feature enabled.
 
 **Known issues and future developments**
 

--- a/docs/releases/versions/version-v4.0.0.md
+++ b/docs/releases/versions/version-v4.0.0.md
@@ -20,7 +20,7 @@ InvenioRDM can now easily integrate with external authentication providers. You 
 
 ![](v4.0/sso1.png)
 
-Read the [Authentication](/customize/authentication/) documentation section to get to know how to set it up.
+Read the [Authentication](../../customize/authentication.md) documentation section to get to know how to set it up.
 
 SAML integration is also supported, but it requires a more advanced setup.
 
@@ -44,14 +44,14 @@ After the first login with an external authentication provider, InvenioRDM can n
 
 When only one external authentication provider is configured, InvenioRDM can be configured to skip the login page and automatically redirect to the external login page.
 
-The [detailed documentation](/customize/authentication/) describes how a new OAuth plugin integration can be implemented.
+The [detailed documentation](../../customize/authentication.md) describes how a new OAuth plugin integration can be implemented.
 
 
 ### Vocabularies
 
 This month we continued work on vocabularies. Most notably we migrated the resource types from the old to the new vocabulary and made them easily customizable.
 
-Read more about this [here](/customize/vocabularies/).
+Read more about this [here](../../customize/vocabularies/index.md).
 
 #### Facets labelling
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -9,6 +9,10 @@
     color: #000000;
 }
 
+.md-nav__title {
+    color: unset;
+}
+
 .md-typeset table code {
     word-break: normal;
 }
@@ -69,6 +73,10 @@
     border-bottom: 0.05rem solid #ffffff;
 }
 
+.md-header__topic:first-child {
+    font-weight: unset;
+}
+
 .md-source__facts {
     display: none;
 }
@@ -80,24 +88,33 @@
 
 .md-footer {
     border-top: 0.05rem solid #ffffff;
+    background-color: #0377cd;
 }
 
 .md-footer__link {
     padding-top: 0.8rem;
     padding-bottom: 0;
-}
-
-.md-footer {
-    background-color: #0377cd;
-}
-.md-footer__link {
     color: #ffffff;
     opacity: 0.75;
+    margin-bottom: 0;
+    margin-top: 0;
 }
 
 .md-footer__direction {
     color: #ffffff;
     opacity: 0.75;
+    font-size: .64rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    padding: 0 1rem;
+    margin-top: -1rem;
+}
+
+.md-footer__title {
+    line-height: 2.4rem;
+    position: relative;
+    margin-bottom: 0;
 }
 
 .md-footer .made-with {
@@ -124,10 +141,25 @@ html .md-footer-meta .md-footer-meta__inner a {
 
 .md-footer-copyright {
     padding: 0.7rem 0;
+    color: var(--md-footer-fg-color--lighter);
+    font-size: .64rem;
+    width: auto;
+    margin: auto .6rem;
+}
+
+.md-footer-copyright__highlight {
+    color: var(--md-footer-fg-color--light);
 }
 
 .md-footer-social {
     padding: 0.4rem 0;
+    margin: 0 .4rem;
+}
+
+.md-footer-social__link svg {
+    fill: currentColor;
+    max-height: .8rem;
+    vertical-align: -25%;
 }
 
 .md-search-result__link[data-md-state="active"] {
@@ -159,6 +191,15 @@ html .md-footer-meta .md-footer-meta__inner a {
     color: #0377cd;
 }
 
+[data-md-color-primary="white"] .md-typeset .md-button.md-button--primary {
+    background-color: var(--md-primary-fg-color);
+    border-color: var(--md-primary-fg-color);
+    color: #0377cd;
+}
+
+[data-md-color-primary="white"] .md-typeset .md-button {
+    color: var(--md-primary-fg-color);
+}
 
 ::placeholder {
     color: #ffffff;
@@ -285,6 +326,7 @@ html .md-footer-meta .md-footer-meta__inner a {
     background: transparent;
     position: static;
 }
+
 .frontpage .md-tabs {
     border-bottom: none;
     background: transparent;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,12 +6,12 @@ site_url: "https://inveniordm.docs.cern.ch"
 repo_url: "https://github.com/inveniosoftware/docs-invenio-rdm"
 
 # Copyright
-copyright: "Copyright &copy; 2019-2022 CERN, Northwestern University and contributors."
+copyright: "Copyright &copy; 2019-2023 CERN, Northwestern University and contributors."
 
 # Configuration
 theme:
   name: "material"
-  custom_dir: "theme"
+  custom_dir: "theme/"
   palette:
     primary: "white"
     accent: "white"
@@ -20,6 +20,7 @@ theme:
   favicon: "images/favicon.svg"
   features:
     - navigation.tabs
+    - navigation.footer
 
 nav:
   - Home: "index.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 mkdocs>=1.0.4
-mkdocs-material>=7.2.1,<7.2.3
-jinja2<3.1
+mkdocs-material>=9.4.14,<10.0

--- a/theme/frontpage_base.html
+++ b/theme/frontpage_base.html
@@ -1,5 +1,5 @@
 {#-
-  This file was automatically generated - do not edit
+  This file was originally automatically generated, but we edited it to customize the frontpage.
 -#}
 {% import "partials/language.html" as lang with context %}
 <!doctype html>
@@ -39,18 +39,9 @@
       {% endif %}
     {% endblock %}
     {% block styles %}
-      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.1118c9be.min.css' | url }}">
-      {% if config.theme.palette %}
-        {% set palette = config.theme.palette %}
-        <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.ba0d045b.min.css' | url }}">
-        {% if palette.primary %}
-          {% import "partials/palette.html" as map %}
-          {% set primary = map.primary(
-            palette.primary | replace(" ", "-") | lower
-          ) %}
-          <meta name="theme-color" content="{{ primary }}">
-        {% endif %}
-      {% endif %}
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.fad675c6.min.css' | url }}">
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.356b1318.min.css' | url }}">
+      <meta name="theme-color" content="{{ primary }}">
     {% endblock %}
     {% block libs %}{% endblock %}
     {% block fonts %}
@@ -168,9 +159,6 @@
                     {% include "partials/source-file.html" %}
                   {% endif %}
                 {% endif %}
-              {% endblock %}
-              {% block disqus %}
-                {% include "partials/integrations/disqus.html" %}
               {% endblock %}
             </article>
           </div>


### PR DESCRIPTION
- links: remove warnings by using .md reference
- mkdocs-material: upgrade to 9.x
- closes #591 

Look-n-feel kept the same as much as possible. Main difference:

**before**

![before_changes_1](https://github.com/inveniosoftware/docs-invenio-rdm/assets/1932651/f9992692-212b-4d21-bc5a-7be2f9ef6c19)

**after**

![new_changes_1](https://github.com/inveniosoftware/docs-invenio-rdm/assets/1932651/bdab8b15-1f90-4003-9afd-18259e284651)
