### PR TITLE
reference: add file before setting default_preview

### DIFF
--- a/docs/reference/rest_api_drafts_records.md
+++ b/docs/reference/rest_api_drafts_records.md
@@ -29,6 +29,8 @@ Used for interacting with unpublished or edited draft records.
 | `default_preview` &nbsp;  | string | body     | Filename of file to be previewed by default. |
 | `order`    | array | body     | Array of filename strings in display order. |
 
+A file must be uploaded to the draft before it can be used as the default
+preview. See "[Start a draft file upload](#start-draft-file-uploads)" below.
 
 **Request**
 


### PR DESCRIPTION
### Description

Add two sentences below the **Files Options** section noting that `files.default_preview` won't work for files that aren't added to the draft yet. I think that the ordering of this document, which first discusses creating a draft with files options included and then later adds the files themselves, makes it unclear the file must be added first. As I started working with the REST API, this would have been useful to know.

`files.order` does not work but I didn't mention that, I couldn't find a precedent for writing Invenio bugs into the documentation, but I could add a note about that too, if desirable.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).
