### PR TITLE
vocabularies: names: link to datasets for all years

### DIFF
--- a/docs/customize/vocabularies/names.md
+++ b/docs/customize/vocabularies/names.md
@@ -17,7 +17,7 @@ A _Name_ record contains:
   are present they will overwrite `name`.
 - A list of `identifiers`, composed by their identifier value and scheme.
   The scheme can potentially be autocompleted if it is known by the _idutils_
-  library (e.g. ORCiD).
+  library (e.g. ORCID).
 - A list of `affiliations`, which can be represented by its `name` or, if it
   belongs to the _Affiliations_ vocabulary, by its `id`.
 
@@ -96,7 +96,7 @@ invenio vocabularies update \
 ### Creating a `names.yaml` file
 
 The Names vocabulary has been implemented with the
-[ORCiD public dataset](https://orcid.figshare.com/articles/dataset/ORCID_Public_Data_File_2021/16750535?file=31020067)
+[ORCID public dataset](https://support.orcid.org/hc/en-us/articles/360006897394-How-do-I-get-the-public-data-file)
 as a possible source to import entries from. This means that the functionality
 to **read** entries from this format is already available. For example, you
 can use the `vocabularies convert` command to convert this dataset into a YAML
@@ -112,7 +112,7 @@ invenio vocabularies convert \
 Alternatively, you can simply import it directly:
 
 !!! warning "Long and blocking operation"
-    Note that the import process is done synchronously and the ORCiD dataset is
+    Note that the import process is done synchronously and the ORCID dataset is
     very large. Therefore, this operation can take a long time.
 
 ```bash


### PR DESCRIPTION
Also fix the case from "ORCiD" to "ORCID".

:heart: Thank you for your contribution!

### Description

The current link points to the ORCID dataset from 2021. The proposal is to change the link to some ORCID documentation which contains the list of the datasets of all years.

I also changed the case from "ORCiD" to "ORCID" since I did not find any official places using this mixed casing.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
