### PR TITLE
how-to: add example bash scripts for backing up stats indices

### DIFF
--- a/docs/develop/howtos/backup_search_indices.md
+++ b/docs/develop/howtos/backup_search_indices.md
@@ -38,7 +38,7 @@ for Elasticsearch), but this should give you an idea where to start.
 For the sake of brevity, this guide only deals with `elasticdump` as it is a very simple
 tool to use and works with both Elasticsearch and OpenSearch.
 
-!!! info "Make sure to back up all indices"
+!!! info "Make sure to back up all relevant indices"
     Please note that the given example only deals with backing up and restoring one single index.
     In your instance, you should make sure to back up *all* relevant indices regularly!
 


### PR DESCRIPTION
This PR adds small `bash` scripts to back up/restore all `stats` indices in one go to the corresponding how-to section.

It's based on shell scripts that I'm currently writing for our own instances.