### PR TITLE
communities api: remove owned_by

### DIFF
--- a/docs/reference/rest_api_communities.md
+++ b/docs/reference/rest_api_communities.md
@@ -20,7 +20,6 @@
 | `visibility`    | string | body     | Required, one of `"public"` or `"restricted"`. Visible by the public or restricted to those who have access.                                                         |
 | `member_policy` | string | body     | Required, one of `"open"` or `"closed"`. Can people request to be part of the community (open) or not (closed)?                                                      |
 | `record_policy` | string | body     | Required, one of `"open"` or `"closed"`. Can community's members submit a record to the community without a review (open), or a review is always necessary (closed)? |
-| `owned_by`      | array  | body     | Array of Objects of the form: `{"user": <user_id> }`. Community owners (admins).                                                                                     |
 
 ### Community metadata
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

owned_by was removed in 2022 in https://github.com/inveniosoftware/invenio-communities/commit/14c4768e1c8d2ab2ed2cb254fc82ffd5a5d3b779#diff-fdb214e572f1f6740d9290cb190a449bf6abd4da7073797e349df6836a31052e.

This will need to be backported to `production`.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
