### PR TITLE
communities api: remove lingering refs to owned_by

### DIFF
--- a/docs/reference/rest_api_communities.md
+++ b/docs/reference/rest_api_communities.md
@@ -72,12 +72,7 @@ Content-Type: application/json
   "access": {
     "visibility": "public",
     "member_policy": "open",
-    "record_policy": "open",
-    "owned_by": [
-      {
-          "user": {user-id}
-      }
-    ],
+    "record_policy": "open"
   },
   "created": "2020-11-27 10:52:23.945755",
   "updated": "2020-11-27 10:52:23.945755",
@@ -471,12 +466,7 @@ Content-Type: application/json
   "access": {
     "visibility": "public",
     "member_policy": "open",
-    "record_policy": "open",
-    "owned_by": [
-      {
-          "user": {user-id}
-      }
-    ],
+    "record_policy": "open"
   },
   "created": "2020-11-27 10:52:23.945755",
   "updated": "2020-11-27 10:52:23.945755",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Removes lingering references to the field "owned_by" that itself was under "access".



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
