### PR TITLE
docs: update broken links for flask-mail config

### DIFF
--- a/docs/customize/emails.md
+++ b/docs/customize/emails.md
@@ -17,7 +17,7 @@ Set this to False when sending actual emails.
 """
 ```
 For more possible adjustments see the
-[flask-mail-documentation](https://pythonhosted.org/Flask-Mail/#configuring-flask-mail).
+[flask-mail-documentation](https://flask-mail.readthedocs.io/en/latest/#configuring).
 
 If `MAIL_SUPPRESS_SEND` is set to `True` you can find the 'sent' emails in the
 logs of the worker:

--- a/docs/develop/howtos/dev_email.md
+++ b/docs/develop/howtos/dev_email.md
@@ -14,7 +14,7 @@ If a system is not listed below, check the original documentation on how to inst
 brew update && brew install mailhog
 ```
 
-and then start MailHog via 
+and then start MailHog via
 
 ```terminal
 mailhog
@@ -57,7 +57,7 @@ MAIL_SUPPRESS_SEND = False
 MAIL_SERVER = '127.0.0.1'
 
 # Configured SMTP server's port
-MAIL_PORT = 1025 
+MAIL_PORT = 1025
 ```
 
 Restart the application and e-mails will be sent to the configured `SMTP` server.
@@ -66,5 +66,5 @@ Check the inbox in [MailHog UI](http://127.0.0.1:8025).
 
 ## Further reading
 
-- How to configure flask mail - [docs](https://pythonhosted.org/Flask-Mail/#configuring-flask-mail)
+- How to configure flask mail - [docs](https://flask-mail.readthedocs.io/en/latest/#configuring)
 - MailHog - [original repo](https://github.com/mailhog/MailHog)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Update dead links to the documentation for "flask-mail," which has moved to [readthedocs](https://flask-mail.readthedocs.io/en/latest/)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
