### PR TITLE
releases: clarify language around how long releases are supported

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,6 @@ hide:
 template: frontpage.html
 ---
 
-!!! tip "August 1st, 2024: InvenioRDM v12.0 Long-term support available! ✨"
+!!! tip "August 1st, 2024: InvenioRDM v12.0 available! ✨"
 
     🚀 Read the full [release notes](releases/v12/version-v12.0.0.md).

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,14 +1,12 @@
 # Releases
 
-
 ## Release cycles
 
-We aim to have a quarterly release cycle, to push out new features as fast as possible.
+We aim to have annual releases, with security and bug fixes as well as small improvements throughout the support period of the release. This cadence is better aligned with our resources and the community's desire for stability, while still allowing for sustained changes (breaking or non-breaking).
 
-Only releases designated **Long-Term Support (LTS)** releases are supported for production services.
+Starting with version 12, each release is production-grade ready. Before v12, only LTS-releases were supported for usage in production.
 
 Our aim is to ensure that users of InvenioRDM follow our latest releases by making the upgrade process a seamless experience.
-
 
 ## Policies
 

--- a/docs/releases/maintenance-policy.md
+++ b/docs/releases/maintenance-policy.md
@@ -8,7 +8,7 @@ Our maintenance policy strives to strike a balance between supporting a rock-sol
 
 Starting with the v12 release, we have shifted from the Long-Term Support (LTS) and Short-Term Support (STS) model to aiming for one stable major release per year.
 
-**Major release:** Major versions, such as v12, introduce new features, make backward incompatible changes and remove deprecated features in a progressive manner. Only the latest minor-level release for each major version is supported. A major version release is supported for 6 months past the next major version release.
+**Major release:** Major versions, such as v12, introduce new features, can make backward incompatible changes, and sometimes remove deprecated features in a progressive manner. Only the latest minor-level release for each major version is supported. A major version release is supported for 6 months past the next major version release. In practice, a major version *could* be incompatible with prior customizations, but not necessarily. It is more often a way for the development team to establish a new set of features/modules for which they guarantee cohesion and for which they limit their attention to.
 
 **Minor releases:** Minor versions, such as v12.1, introduce backward compatible changes in a manner that allows users to easily upgrade.
 

--- a/docs/releases/maintenance-policy.md
+++ b/docs/releases/maintenance-policy.md
@@ -1,30 +1,31 @@
 # Maintenance policy
 
-Our goal is to ensure that the latest InvenioRDM release is supported with bug and security fixes for minimum one year after the release date, and possibly longer.
-We aim at having a new release every year. We strive our best to ensure that upgrades between versions are fairly straight-forward to ensure users follow our latest releases.
+Our goal is to ensure that the latest InvenioRDM release is supported with bug and security fixes for a minimum of one year after its release date, and 6 months after the next latest release. This promotes stability and gives adopters a dependable transition period. We aim at having a new release every year. We strive our best to ensure that upgrades between versions are straight-forward to ensure users follow our latest releases.
 
-The maintenance policy is striving to strike a balance between maintaining a rock solid secure product while ensuring that users migrate to latest releases and ensuring that we have enough resources to actually support the maintenance policy.
+Our maintenance policy strives to strike a balance between supporting a rock-solid secure product, shipping new features + refactoring old code, and ensuring that we have enough resources to do all this. It pushes users to adopt the latest version, so that they can benefit from continued support. Most new features are behind configuration flags, so they can be gradually adopted though.
 
 ## Policy
 
 Starting with the v12 release, we have shifted from the Long-Term Support (LTS) and Short-Term Support (STS) model to aiming for one stable major release per year.
 
-**Major release:** Major versions such as v12 allow us to introduce new features, make backward incompatible changes and remove deprecated features in a progressive manner. Only the latest minor-level release for each major version is supported. A major version release is supported until the next major version release.
+**Major release:** Major versions, such as v12, introduce new features, make backward incompatible changes and remove deprecated features in a progressive manner. Only the latest minor-level release for each major version is supported. A major version release is supported for 6 months past the next major version release.
 
-**Minor releases:** Minor versions such as v3.1 allow us to introduce backward compatible changes in a manner that allow users to easily upgrade.
+**Minor releases:** Minor versions, such as v12.1, introduce backward compatible changes in a manner that allows users to easily upgrade.
 
-**Patch releases:** Patch versions such as v3.0.1 allow us to fix bugs and security issues in a manner that allows users to upgrade immediately without breaking backward compatibility.
+**Patch releases:** Patch versions, such as v12.0.1, allow us to fix bugs and security issues in a manner that allows users to upgrade immediately without breaking backward compatibility.
 
 We may make exceptions to this policy for serious security bugs.
 
-### End of life dates
+## Support periods
 
-Following is an overview of future end of life (EOL) dates for currently maintained releases:
+Following is an overview of future end of life (EOL) dates for recent releases:
 
-| Release     | Earliest EOL Date | Maintained until    |
-| ----------- | ----------------- | ------------------- |
-| v12.0.0     |                   | next release        |
-| v11.0.0 STS |                   | next release        |
-| v10.0.0 STS |                   | next SLS            |
-| v9.0.0 LTS  | 2023-05-24        | next LTS + 6 months |
-| v6.0.0 LTS  |                   | 2022-12-31          |
+| Release     | Date       | Maintained | Until                                              |
+| ----------- | ---------- | ---------- | -------------------------------------------------- |
+| v12.0.0     | 2024-08-01 | ✅         | next release + 6 months - Earliest EOL: 2026-02-01 |
+| v11.0.0 STS | 2023-01-26 | ❌         | 2024-08-01                                         |
+| v10.0.0 STS | 2022-10-10 | ❌         | 2023-01-26                                         |
+| v9.X LTS    | 2022-05-24 | ❌         | 2025-02-01                                         |
+| v6.0.0 LTS  | 2021-08-05 | ❌         | 2022-12-31                                         |
+
+If your version is not listed, then it is not maintained anymore.

--- a/theme/frontpage.html
+++ b/theme/frontpage.html
@@ -10,14 +10,27 @@
 -->
 {% extends "main.html" %}
 
-{% macro render(nav_item, path, level) %}
+
+{% macro first_url(nav_item) %}
+  {# Returns the first link (if possible) that should be attributed to nav_item.
+
+    In particular, if nav_item contains deeply nested sections before an actual page
+    `first_url` will find the URL for that page.
+  #}
   {% if nav_item.url %}
     {% set link = nav_item.url | url %}
   {% elif nav_item.children %}
-    {% set link = nav_item.children[0].url | url %}
+    {% set link = first_url(nav_item.children[0]) %}
   {% else %}
     {% set link = "" %}
-  {% endif %}
+  {%endif%}
+  {{ link }}
+{% endmacro %}
+
+
+{% macro render(nav_item, path, level) %}
+  {# Renders the nav_item section: its title and first level subsections #}
+  {% set link = first_url(nav_item) %}
   {% if nav_item.children and level <= 1 %}
     <li class="rdm-toc-item level{{level}} nested">
       <div>


### PR DESCRIPTION
- From 2025-03-10 DWG action item.
- Includes a fix for frontpage "Legacy Versions" link wrongly linking to frontpage.