### PR TITLE
v12: add known issue about `RDMRecordQuota.user_id` uniqueness

### DIFF
--- a/docs/releases/v12/version-v12.0.0.md
+++ b/docs/releases/v12/version-v12.0.0.md
@@ -151,6 +151,8 @@ Here is a quick summary of the myriad other improvements in this release:
 - Translations for v12 will be coming in v12.1 targeted for release in two months time from the release of v12.0
 - Sharing a secret link to a restricted record in a restricted community does not provide access to the record yet.
   Work on this is [tracked here](https://github.com/inveniosoftware/invenio-app-rdm/issues/2706).
+- For each user, only one record can have its storage quota increased via the administration panel, due to an overzealous `unique` constraint.
+  The fix (in [Invenio-RDM-Records PR#2037](https://github.com/inveniosoftware/invenio-rdm-records/pull/2037)) will not be backported to v12.
 
 ## Requirements
 


### PR DESCRIPTION
This documents the fact that https://github.com/inveniosoftware/invenio-rdm-records/pull/2037 won't be backported to v12.