### PR TITLE
docs: update outdated configuration parameter

### DIFF
--- a/docs/operate/customize/require_community.md
+++ b/docs/operate/customize/require_community.md
@@ -1,11 +1,11 @@
 # Require community for record publication
 
-Institutional policies may require all published records to belong to at least one community. InvenioRDM enforces this requirement through the `RDM_RECORD_ALWAYS_IN_COMMUNITY` configuration parameter.
+Institutional policies may require all published records to belong to at least one community. InvenioRDM enforces this requirement through the `RDM_COMMUNITY_REQUIRED_TO_PUBLISH` configuration parameter.
 To activate this feature, open your `invenio.cfg` and add:
 
 ```python
 # Require community membership for all published records
-RDM_RECORD_ALWAYS_IN_COMMUNITY = True
+RDM_COMMUNITY_REQUIRED_TO_PUBLISH = True
 ```
 
 Default State: Disabled `False`
@@ -26,7 +26,7 @@ Only users with specific privileges (by default, administrators with `superuser`
 
 ### Granting Community Creation Rights
 
-When enabling `RDM_RECORD_ALWAYS_IN_COMMUNITY`, note that community creation permissions remain separate. By default, anyone can create communities. Institutions have different requirements for who can create communities, and InvenioRDM provides flexible configuration. Below is one example approach using custom roles to restrict community creation to a specific role, such as "community-curator".
+When enabling `RDM_COMMUNITY_REQUIRED_TO_PUBLISH`, note that community creation permissions remain separate. By default, anyone can create communities. Institutions have different requirements for who can create communities, and InvenioRDM provides flexible configuration. Below is one example approach using custom roles to restrict community creation to a specific role, such as "community-curator".
 To implement this, follow these steps:
 
 1- Create permission generators:
@@ -76,7 +76,7 @@ class CustomCommunitiesPermissionPolicy(CommunityPermissionPolicy):
 
 ```python
 # Enable community requirement
-RDM_RECORD_ALWAYS_IN_COMMUNITY = True
+RDM_COMMUNITY_REQUIRED_TO_PUBLISH = True
 
 from yourmodule.permissions import CustomCommunitiesPermissionPolicy
 # Apply custom permissions


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Replaced references to `RDM_RECORD_ALWAYS_IN_COMMUNITY` with
`RDM_COMMUNITY_REQUIRED_TO_PUBLISH`




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
