### PR TITLE
jobs: remove string cast for `since` argument

### DIFF
--- a/docs/operate/customize/jobs.md
+++ b/docs/operate/customize/jobs.md
@@ -56,7 +56,7 @@ class UpdateEmbargoesJob(JobType):
 
     @classmethod
     def build_task_arguments(cls, job_obj, since=None, **kwargs):
-        return {"since": str(since)}
+        return {"since": since}
 ```
 
 To include custom fields in the admin form, define a Marshmallow schema:
@@ -82,7 +82,7 @@ class UpdateEmbargoesJob(JobType):
     @classmethod
     def build_task_arguments(cls, job_obj, since=None, dry_run=False, **kwargs):
         return {
-            "since": str(since) if since else None,
+            "since": since,
             "dry_run": dry_run
         }
 ```


### PR DESCRIPTION
**Please release this PR at the same time as the other changes mentioned in https://github.com/inveniosoftware/invenio-jobs/issues/87#issuecomment-3045453052**

---

* The `since` parameter was string-cast to fix a previous bug in Oct 2024 across multiple Invenio modules, e.g. in `invenio-vocabularies`:
https://github.com/inveniosoftware/invenio-vocabularies/pull/419

* In https://github.com/inveniosoftware/invenio-jobs/issues/87, this string cast is now being removed. The documentation has been updated to no longer recommend adding this string cast.