### PR TITLE
docs: fix notifications customize example

### DIFF
--- a/docs/operate/customize/notifications.md
+++ b/docs/operate/customize/notifications.md
@@ -140,7 +140,10 @@ class CustomSubmissionBuilder(CommunityInclusionSubmittedNotificationBuilder):
 This builder can now be specified (e.g. in `invenio.cfg`):
 
 ```py
+from invenio_app_rdm.config import NOTIFICATIONS_BUILDERS
+
 NOTIFICATIONS_BUILDERS = {
+    **NOTIFICATIONS_BUILDERS, # Keep all other builders
     CustomSubmissionBuilder.type: CustomSubmissionBuilder,
 }
 ```


### PR DESCRIPTION
* The current notifications builder example removes all the builders
  Invenio-App-RDM configures resulting in several exceptions raised when
  running it due to missing builders.

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
