### PR TITLE
fix: remove duplicate invenio rdm cmds section

### DIFF
--- a/docs/reference/cli_invenio.md
+++ b/docs/reference/cli_invenio.md
@@ -201,49 +201,6 @@ Manage events queue.
 
 Invenio app RDM commands.
 
-| Command             | Description                                    |
-| :------------------ | :--------------------------------------------- |
-| fixtures            | Create the fixtures.                           |
-| pages               | Static pages.                                  |
-| rebuild-all-indices | Schedule reindexing of (all) items for search. |
-
-### **`rdm pages`**
-
-see [Static pages](../operate/customize/static_pages.md).
-
-### **`rdm pages create`**
-
-**Options**
-
-- `-f`, `--force` Creates static pages.
-
-### **`rdm fixtures`**
-
-Create the fixtures.
-
-### **`rdm rebuild-all-indices`**
-
-Reindex all services with optional selecting and ordering.
-
-**Options**
-
-- `-o`, `--order` Comma-separated list of services to reindex in the specified order. If not provided, all services will be reindexed.
-  e.g.:
-
-```bash
-invenio rdm rebuild-all-indices -o users,communities,records,requests,request_events
-```
-
-if you don't specify services, The following services will be reindexed:
-
-`users, groups, domains, communities, members, records, record-media-files, affiliations, awards, funders, names, subjects, vocabularies, requests, request_events, oaipmh-server`
-
-Note that the users, groups, and members use bulk indexing and rely on celery running. They will not be reindexed if celery is not running.
-
-This command does not impact usage statistics indexes. You need to manually restore statistics indexes [from a backup](../operate/ops/backup_search_indices.md).
-
-## `invenio rdm` commands
-
 | Command             | Description                                                                         |
 | :------------------ | :---------------------------------------------------------------------------------- |
 | fixtures            | Create the fixtures.                                                                |


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

It looks likes the `invenio rdm commands` section is repeated twice on the invenio commands reference page. This removes the duplicate section and keeps the one that has the commands in alphabetical order.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
