### PR TITLE
docs: add CORS rules for S3 multipart upload

### DIFF
--- a/docs/operate/customize/file-uploads/uploader.md
+++ b/docs/operate/customize/file-uploads/uploader.md
@@ -89,4 +89,23 @@ You can choose which uploader to use by toggling the `APP_RDM_DEPOSIT_NG_FILES_U
     }
     ```
 
+    Furthermore, when using S3 compatible storage backend make sure the CORS (Cross-Origin Resource Sharing) of your S3 storage are adjusted as follows:
+    ```
+    [
+        {
+            "AllowedHeaders": [
+                "*"
+            ],
+            "AllowedMethods": [
+                "GET",
+                "PUT"
+            ],
+            "AllowedOrigins": [
+                "*"
+            ],
+            "ExposeHeaders": []
+        }
+    ]
+    ```
+
 Restart your site after changing the configuration to ensure the new UI is properly loaded.


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

When using Uppy Uploader and S3 storage backend, the CORS rules as described in https://inveniordm.docs.cern.ch/operate/customize/file-uploads/s3/#amazon-s3 are not sufficient for the multipart upload to work. This PR aims at documenting the necessary change in the section of the Uppy configuration. However, we are not exactly sure if the rules especially the allowed header can be further restricted.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
