### PR TITLE
docs: remove deprecated enable jobs config

### DIFF
--- a/docs/operate/customize/jobs.md
+++ b/docs/operate/customize/jobs.md
@@ -5,13 +5,6 @@ _Introduced in v13_
 
 A job is a wrapper around a `Celery` task that can be scheduled, run on demand, and managed via the administration interface. You can also monitor the execution status of each job, run history, and logs.
 
-## Enable jobs
-To enable the job system, you need to set the following configuration in your `invenio.cfg` file:
-
-```bash
-JOBS_ADMINISTRATION_ENABLED=True
-```
-
 ## Scheduler
 The Invenio job system uses a custom Celery task scheduler which requires a separate Celery beat. You can run the custom beat in a separate container or shell like so:
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* The instructions to enable the job system in the
`invenio.cfg` file have been removed as they are
no longer necessary for the current setup.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
