### PR TITLE
fix: 2 broken links on authentication page

### DIFF
--- a/docs/operate/customize/authentication.md
+++ b/docs/operate/customize/authentication.md
@@ -1043,10 +1043,9 @@ Below, you can find **an example** of how you can add a `RoleNeed` on login.
 !!! warning "Use at your own risk"
     The integration of groups is not fully tested yet and the code below is just an example of a possible implementation.
 
-Assuming you're implementing a custom
-[OAuth plugin](https://inveniordm.docs.cern.ch/customize/authentication/#new-oauth-plugins),
+Assuming you're implementing a custom [OAuth plugin](#new-oauth-plugins),
 the fetching of user groups can happen after having fetched user information with the
-[`signup_handler.info`](https://inveniordm.docs.cern.ch/customize/authentication/#allowdeny-user-login) handler.
+[`signup_handler.info`](#allowdeny-user-login) handler.
 
 ```python
 def info_handler(remote, resp):


### PR DESCRIPTION
### Description

> Please describe briefly your pull request.

Fix two broken links on Operate > Customize > Authentication page in the "[Assign groups on login](https://inveniordm.docs.cern.ch/operate/customize/authentication/#allowdeny-user-login)" section. These were absolute URLs pointing to the wrong path, but their destination is on the same page, so I think they should be OK as anchor links.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.
