### PR TITLE
Add 2 fields to Community Access REST API

### DIFF
--- a/docs/reference/rest_api_communities.md
+++ b/docs/reference/rest_api_communities.md
@@ -13,7 +13,7 @@
 | `slug`     | string | body     | Required, url-compatible, max 100 char. The identifier of the community that will be used in the community's URL. |                                                  |
 | `metadata` | object | body     | [Metadata](#community-metadata) of the community.                                                                 |
 
-### Community access
+#### Community access
 
 | Name            | Type   | Location | Description                                                                                                                                                          |
 |-----------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -23,7 +23,7 @@
 | `record_policy` | string | body     | Required, one of `"open"` or `"closed"`. Can community's members submit a record to the community without a review (open), or a review is always necessary (closed)? |
 | `review_policy` | string | body     | Optional, one of `"closed"`, `"open"`, or `"members"`. If `"closed"` (default), all submissions must be reviewed. If `"open"`, Curators/Managers/Owners can publish directly. If `"members"`, all community members can publish directly. |
 
-### Community metadata
+#### Community metadata
 
 | Name              | Type   | Location | Description                                                                                                       |
 |-------------------|--------|----------|-------------------------------------------------------------------------------------------------------------------|

--- a/docs/reference/rest_api_communities.md
+++ b/docs/reference/rest_api_communities.md
@@ -19,7 +19,9 @@
 |-----------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `visibility`    | string | body     | Required, one of `"public"` or `"restricted"`. Visible by the public or restricted to those who have access.                                                         |
 | `member_policy` | string | body     | Required, one of `"open"` or `"closed"`. Can people request to be part of the community (open) or not (closed)?                                                      |
+| `members_visibility` | string | body | Optional, one of `"public"` or `"restricted"`. If `"public"` (default), members who have set their visibility to public are visible to anyone. Otherwise, members are only visible to other members. |
 | `record_policy` | string | body     | Required, one of `"open"` or `"closed"`. Can community's members submit a record to the community without a review (open), or a review is always necessary (closed)? |
+| `review_policy` | string | body     | Optional, one of `"closed"`, `"open"`, or `"members"`. If `"closed"` (default), all submissions must be reviewed. If `"open"`, Curators/Managers/Owners can publish directly. If `"members"`, all community members can publish directly. |
 
 ### Community metadata
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

The REST API lets you specify the members visibility and review policy of communities but this isn't in [the documentation](https://inveniordm.docs.cern.ch/reference/rest_api_communities/#community-access).

Someone should check my work here but in my testing these are the correct options and defaults. The fields definitely are optional because community creation requests without them work fine.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
