### PR TITLE
fix: pin bcrypt version  note

### DIFF
--- a/docs/releases/vNext/version-vNext.md
+++ b/docs/releases/vNext/version-vNext.md
@@ -33,6 +33,7 @@ https://github.com/inveniosoftware/invenio-previewer/pull/224
 Here is a quick summary of the myriad of other improvements in this release:
 
 - Admin panel Jobs: Added a "Delete" action to the Jobs list so admins can remove jobs directly from the UI.
+- Temporarily pinned `bcrypt<5.0.0` due to compatibility issues ([flask-security-fork#82](https://github.com/inveniosoftware/flask-security-fork/pull/82)). Will be lifted in a future release.
 
 ## Deprecations
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Temporarily pinned `bcrypt<5.0.0` to address compatibility issues
with flask-security-fork. This will be lifted in a future release.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
