### PR TITLE
fix: remove outdated affiliations link

### DIFF
--- a/docs/operate/customize/vocabularies/affiliations.md
+++ b/docs/operate/customize/vocabularies/affiliations.md
@@ -57,8 +57,6 @@ affiliations:
       data-file: vocabularies/affiliations_ror.yaml
 ```
 
-The `affiliations_ror.yaml` file can be downloaded from [here](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/raw/master/%7B%7Bcookiecutter.project_shortname%7D%7D/app_data/vocabularies/affiliations_ror.yaml).
-
 Afterwards you will need to import the affiliations. To do so, run the following command
 from your instance's folder:
 


### PR DESCRIPTION
* The download link for the affiliations_ror.yaml file has been removed.
* see: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/282

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
