### PR TITLE
feat(vNext): support for wikidata id scheme added

### DIFF
--- a/docs/releases/vNext/version-vNext.md
+++ b/docs/releases/vNext/version-vNext.md
@@ -46,7 +46,7 @@ Here is a quick summary of the myriad of other improvements in this release:
 - A new configuration variable, `RDM_RECORDS_RELATED_IDENTIFIERS_SCHEMES`, enables configuring identifier schemes specifically for related identifiers, defaulting to `RDM_RECORDS_IDENTIFIERS_SCHEMES` when not defined.
 - Deposit form: label/help text changes for Authors and Contributors: https://github.com/inveniosoftware/invenio-app-rdm/issues/3197
 - A new configuration variable, `RDM_RECORDS_REQUIRE_SECRET_LINKS_EXPIRATION`, controls whether an expiration date must be set for access links and secret links. Defaults to `FALSE` when not defined.
-- Add support of wikidata identifiers. 
+- Add support for Wikidata identifiers (QIDs) for creators and contributors of records and their affiliations. 
 
 ## Deprecations
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Recently the support of wikidata id scheme has been added. Put a sentence in the vNext-docs.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
