### PR TITLE
Add v13.1 release docs

### DIFF
--- a/docs/maintenance/architecture/requests.md
+++ b/docs/maintenance/architecture/requests.md
@@ -93,6 +93,7 @@ removed from the database in this case.
 Reviewers are optional participants in a request process. They provide expert opinions, feedback, or recommendations but cannot make the final decision to accept or decline the request. That responsibility lies solely with the receiver.
 
 Key characteristics of reviewers:
+
 - Can be individual users or groups
 - Multiple reviewers can be assigned to a single request
 - Do not have direct authority to accept or decline the request

--- a/docs/releases/v13/version-v13.1.0.md
+++ b/docs/releases/v13/version-v13.1.0.md
@@ -1,0 +1,90 @@
+# InvenioRDM v13.1
+
+*2026-03-27*
+
+We are happy to announce the release of InvenioRDM v13.1. This is a minor release which will become the maintained tip of v13.
+Future patches for v13 will land on this minor version only.
+
+
+## What's new?
+
+InvenioRDM v13.1 primarily backports the [request reviewers feature](../../maintenance/architecture/requests.md#reviewers-in-requests) to InvenioRDM v13.
+
+This feature allows the selection of users (or groups) as "reviewers" for requests.
+The selected reviewers will gain access to the request and its timeline (i.e. associated events and comments), and be able to comment on the request too.
+
+!!! warning "Enabling the feature requires reindexing the requests"
+    The information about the set of reviewers is stored in a new field in the request itself, so the schema has changed.
+    Enabling the feature will require the search mappings to be updated, and the requests to be reindexed.
+    For more details, see the [upgrade section below](#upgrading-from-v130-to-v131).
+
+
+### Selecting reviewers for requests
+
+The new request reviewers feature is (currently) opt-in, so you'll have to enable the `REQUESTS_REVIEWERS_ENABLED` feature flag via the configuration.
+Additionally, the behavior can be tweaked with a few more configuration items:
+
+```python
+REQUESTS_REVIEWERS_ENABLED = True
+"""Enable the request reviewers feature."""
+
+REQUESTS_REVIEWERS_MAX_NUMBER = 15
+"""Maximum number of reviewers allowed for a request."""
+
+USERS_RESOURCES_GROUPS_ENABLED = True
+"""Config to enable features related to existence of groups.
+
+Makes groups available for selection as request reviewers, in addition to users.
+"""
+```
+
+**Note** that the feature flag currently enables the request reviewers feature for *all kinds of requests*.
+
+
+### Other notable changes
+
+Even though the upgrade pulls in a number of major version bumps, there are actually only relatively few large changes.
+Most of the major releases there just bump their own dependencies (to better isolate from breaking changes) rather than introducing breaking changes themselves.
+
+Here are the most noteworthy changes:
+
+* [`Invenio-Users-Resources` v9.0.0](https://pypi.org/project/invenio-users-resources/9.0.3/): Tightened permissions for users endpoints in the REST API, and change of HTTP status code from `403` to `404` on permission errors for increased privacy
+* [`Invenio-RDM-Records` v20.2.0](https://pypi.org/project/invenio-rdm-records/20.2.0/): Renaming of several `React-Overridable` IDs; the full list of changed IDs is available in the [changelog for v20.2.0](https://github.com/inveniosoftware/invenio-rdm-records/blob/v20.2.0/CHANGES.rst?plain=1)
+
+
+
+## Upgrading from v13.0 to v13.1
+
+
+The first step of the upgrade process is of course to **install the new packages**.  
+To do so, make sure that the version specifiers for the Invenio-App-RDM dependency in your project definition (`pyproject.toml`, `Pipfile`, ...) allow for the `13.1.x` range of releases, e.g. `invenio-app-rdm[opensearch2]~=13.1.0`.
+
+The new packages should be found and installed via `invenio-cli install`.  
+If the v13.1 release of Invenio-App-RDM still doesn't get pulled in, remove your lock file (`uv.lock`, `Pipfile.lock`, ...) and try again.
+
+After installing the new packages, you'll need to **rebuild your frontend assets**, and **update the search mappings for the requests index and reindex all requests**.
+
+For *local development setups*, the frontend assets have been built as part of `invenio-cli install` already.  
+For *containerized setups*, this typically just requires rebuilding your container images; the frontend build is part of the default [`Dockerfile`](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/blob/v13.0/%7B%7Bcookiecutter.project_shortname%7D%7D/Dockerfile).
+If the frontend assets seem stale after spinning up the newly built containers, the culprit is often an outdated `static_data` volume.
+Removing it and restarting the containers usually fixes this issue.
+Just make sure not to delete the wrong volumes!
+
+The search mappings and indexed requests can be updated with the following commands:
+
+```bash
+# update the search mappings for requests to include reviewers
+invenio index update requests-request-v1.0.0 --no-check
+
+# start bulk reindexing for all requests
+invenio rdm rebuild-all-indices --order requests
+```
+
+That's it.
+Other search indices like request events aren't affected and don't need to be updated.
+
+!!! info "No action needed if you don't want to use the feature"
+    If you *do not* intend to enable the request reviewers feature, no further action is necessary after upgrading the installed packages.
+    But updating the mappings won't hurt either.
+
+Enjoy v13.1! 😎

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ nav:
       - Upgrade policy: releases/upgrade-policy.md
       - Security policy: releases/security-policy.md
       - Version v13:
+          - Release Notes v13.1: releases/v13/version-v13.1.0.md
           - Release Notes v13.0: releases/v13/version-v13.0.0.md
           - Upgrade from v12 to v13: releases/v13/upgrade-v13.0.md
       - Version v12:


### PR DESCRIPTION
This PR references the request reviewers feature documentation, so it depends on https://github.com/inveniosoftware/docs-invenio-rdm/commit/a25e8fb47ef9f5bd91b2abc111a1589ca69c50dc and https://github.com/inveniosoftware/docs-invenio-rdm/commit/9961d4dac3aacedbc344e18e4c14e9266e84453c (relevant for deployment to `inveniordm.docs.cern.ch`)

# Screenshot

<img width="2560" height="3116" alt="image" src="https://github.com/user-attachments/assets/d6431aef-74ae-4bbc-a97d-d62b4063ffd4" />