### PR TITLE
feat: update default ports for SITE_UI_URL and SITE_API_URL

### DIFF
--- a/docs/releases/vNext/upgrade-vNext.md
+++ b/docs/releases/vNext/upgrade-vNext.md
@@ -475,6 +475,16 @@ If you've customized any of these vocabularies for your instance, you'll need to
 
 ### Required changes
 
+When running `invenio-cli run` with `--host`/`--port` passed on the command line or host/port defined in `.invenio.private`, it used to be that those values would override `SITE_UI_URL` and `SITE_API_URL`. This is no longer the case in order to allow for listening on a host/port (defined by passed host and port) different than the host/port used to generate the URLs. This is a common situation when listening on 0.0.0.0 and using the exact IP or fully qualified domain name for URL generation. As such you need to provide the appropriate `SITE_UI_URL` and `SITE_API_URL` values for your environment which typically means:
+
+```diff
+-SITE_UI_URL = "https://127.0.0.1"
++SITE_UI_URL = "https://127.0.0.1:5000"
+
+-SITE_API_URL = "https://127.0.0.1/api"
++SITE_API_URL = "https://127.0.0.1:5000/api"
+```
+
 #### Overridable IDs in the deposit form
 
 To improve consistency in naming conventions and structure, some IDs of Overridables in the deposit form have been modified. If you are overriding any of these components, you will need to change the ID in your mapping file to reflect these modifications.


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* The configuration defaults now include the port for both URLs.
* Ensure proper access to the site and API endpoints.
* related to https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/330




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
