### PR TITLE
curation(i18n): support multilingual rule configurations

### DIFF
--- a/docs/maintenance/architecture/curation.md
+++ b/docs/maintenance/architecture/curation.md
@@ -51,9 +51,15 @@ A rule configuration is a dictionary with the following structure:
 ```python
 {
     "id": "unique-rule-id",  # Required
-    "title": "Human-readable title",
-    "message": "Error message shown when rule fails",
-    "description": "Detailed description of the rule",
+    "title": {
+        "en": "Human-readable title",
+    },
+    "message": {
+        "en": "Error message shown when rule fails"
+    },
+    "description": {
+        "en": "Detailed description of the rule"
+    },
     "level": "info|warning|failure",  # Default: "info"
     "condition": {  # Optional condition expression
         "type": "expression_type",
@@ -69,6 +75,13 @@ A rule configuration is a dictionary with the following structure:
 ```
 
 This object is stored in the `params` section of the `CheckConfig` model in the database.
+
+_Introduced in v14_
+
+Rule `title`, `message`, and `description` values support multilingual dictionaries keyed by locale (for example, `en`, `sv`). Plain string values remain supported for backwards compatibility.
+
+!!! Warning "Known limitation"
+    Plain string results are stored as-is and shown unchanged to all viewers. This can matter when submitters and reviewers use different locales. Checks that need per-viewer localization should return multilingual dictionaries with an English fallback.
 
 ### Expression types
 
@@ -160,15 +173,25 @@ Here's a complete example showing multiple rules with different expression types
 ```python
 {
     "id": "metadata-validation",
-    "title": "Metadata Validation",
-    "description": "Validates basic metadata requirements",
+    "title": {
+        "en": "Metadata Validation"
+    },
+    "description": {
+        "en": "Validates basic metadata requirements"
+    },
     "rules": [
         {
             "id": "license:exists",
             "level": "error",
-            "title": "Record license",
-            "message": "Licenses are required.",
-            "description": "All submissions must specify the licensing terms.",
+            "title": {
+                "en": "Record license"
+            },
+            "message": {
+                "en": "Licenses are required."
+            },
+            "description": {
+                "en": "All submissions must specify the licensing terms."
+            },
             "checks": [
                 {
                     "path": "metadata.rights",
@@ -181,9 +204,15 @@ Here's a complete example showing multiple rules with different expression types
         {
             "id": "creators:identifier",
             "level": "info",
-            "title": "Creator Identifiers",
-            "message": "Affiliations are recommended for all creators",
-            "description": "All creators should have a persistent identifier (e.g. an ORCID)",
+            "title": {
+                "en": "Creator Identifiers"
+            },
+            "message": {
+                "en": "Affiliations are recommended for all creators"
+            },
+            "description": {
+                "en": "All creators should have a persistent identifier (e.g. an ORCID)"
+            },
             "condition": {
                 "path": "metadata.creators",
                 "type": "list",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Update rule configuration to allow multilingual dictionaries for title, message, and description.
* Add warning about known limitations with plain strings.

* related https://github.com/inveniosoftware/invenio-app-rdm/issues/3499



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
