### PR TITLE
docs: fix sort example to use metadata.title.keyword

### DIFF
--- a/docs/operate/customize/search.md
+++ b/docs/operate/customize/search.md
@@ -97,10 +97,20 @@ from invenio_rdm_records.config import RDM_SORT_OPTIONS
 RDM_SORT_OPTIONS.update({
     "title": dict(
         title=_('Title'),
-        fields=['metadata.title'],
+        fields=['metadata.title.keyword'],
     ),
 })
 ```
+
+!!! note
+
+    When sorting on a text field such as ``metadata.title``, use its
+    ``.keyword`` sub-field (``metadata.title.keyword``). Analyzed ``text``
+    fields are tokenized for full-text search and cannot be sorted on
+    directly, whereas the ``.keyword`` sub-field stores the raw value as an
+    exact-match ``keyword`` type that is sortable. Numeric and date fields
+    (for example ``-created``) can be sorted on directly and do not require
+    ``.keyword``.
 
 Note, that this only defines a new sort option. You still need to change e.g.
 ``RDM_SEARCH`` to use it.


### PR DESCRIPTION
Fixes #899

:heart: Thank you for your contribution!

### Description

The custom sort example in operate/customize/search.md used
`fields=['metadata.title']`, which fails because analyzed text fields
cannot be sorted on directly. This updates the example to use the
sortable `.keyword` sub-field and adds a note explaining when
`.keyword` is needed.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [ ] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
