### PR TITLE
requests: document upgrading/configuring per-record-version reviews

### DIFF
--- a/docs/operate/customize/requests.md
+++ b/docs/operate/customize/requests.md
@@ -38,11 +38,11 @@ USERS_RESOURCES_GROUPS_ENABLED = True
 ```
 then you will be able to use them as request reviewers.
 
-- **Use cases**:
-  - Institutional Review Boards
-  - Editorial committees
-  - Subject matter expert panels
-  - Department review teams
+- **Use cases**: 
+    - Institutional Review Boards
+    - Editorial committees
+    - Subject matter expert panels
+    - Department review teams
 - **Behavior**: All members of the assigned group receive access to view and comment on the request
 - **Notifications**: Group members may receive notifications based on your notification configuration
 
@@ -61,10 +61,59 @@ Reviewers can view the request, participate in conversations, and provide recomm
 ## Permissions
 
 By default, reviewers can be added or removed by community members with roles:
-- **Owners** and **managers** can assign/remove reviewers
+
+- **Owners** and **Managers** can assign/remove reviewers
 - **Curators** can assign/remove reviewers
 
-Community members with the role: *Readers** cannot assign reviewers but can be assigned as reviewers.
+Community members with the role **Reader** cannot assign reviewers but can be assigned as reviewers.
+
+## Require reviews for each record version
+
+By default, only the first version of a record submitted to a community is subject to a review request (depending on the community's settings).
+This can be changed to also require reviews for new record versions.
+
+To do so, you need to override the [`NewRecordVersionPolicy`](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/services/review/policy.py#L7) class in your instance.
+This class contains one method that is called when the user clicks the "New version" button, and is passed the new version draft as well as the identity of the user.
+This method can contain any custom logic that returns a boolean value, indicating whether the new version draft should be subject to a review.
+
+New version reviews can only be created for the **default community of the record**.
+
+For example, you can use a config variable to specify communities that require a review for all record versions:
+
+```python
+# record_version_policy.py
+
+from flask import current_app
+from invenio_rdm_records.services.review import NewRecordVersionReviewPolicy
+
+class CustomVersionReviewPolicy(NewRecordVersionReviewPolicy):
+    """Policy override."""
+
+    @classmethod
+    def requires_review(cls, identity, draft) -> bool:
+        """Returns whether the new record version requires review."""
+        default_community = draft.parent.communities.default
+        if default_community is None:
+            return False
+
+        communities_requiring = current_app.config.get(
+            "COMMUNITIES_REQUIRING_REVIEW_FOR_ALL_VERSIONS", []
+        )
+        return (
+            str(default_community.id) in communities_requiring
+        )
+```
+
+Then, add the overridden policy to your instance's configuration:
+
+```python
+# invenio.cfg
+
+from record_version_policy import CustomVersionReviewPolicy
+
+RDM_NEW_RECORD_VERSION_REVIEW_POLICY = CustomVersionReviewPolicy
+COMMUNITIES_REQUIRING_REVIEW_FOR_ALL_VERSIONS = ["10e21709-1795-4858-a068-f41135c5ab9b"]
+```
 
 ## Related configuration
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -562,6 +562,11 @@ The new feature of allowing replies to comments available in all requests introd
 
 The new feature of allowing locking/unlocking a request's conversation is controlled via a feature flag config variable `REQUESTS_LOCKING_ENABLED`.
 
+### Community reviews for each record version
+
+The new feature of requiring community reviews for each version of a record (rather than just the first) must be [manually configured](../../operate/customize/requests.md#require-reviews-for-each-record-version).
+The default behaviour remains unchanged.
+
 ### Deprecated GitHub integration
 
 The [`invenio-github`](https://github.com/inveniosoftware/invenio-github) module has been deprecated.

--- a/docs/releases/v14/version-v14.0.md
+++ b/docs/releases/v14/version-v14.0.md
@@ -34,7 +34,7 @@ page. Users can filter records by year using a histogram and range slider, or
 pick from preset ranges (last 6 months, last year, last 5 years) and enter a
 custom date range.
 
-![Publication date range facet](../../operate/customize/imgs/publication-date-range-facet.png)
+![Publication date range facet](../../operate/customize/imgs/publication-date-range-facet.png){ width="300" }
 
 You can enable additional date facets, tune backend aggregation settings, and
 override the frontend UI. See [Configure date range
@@ -127,6 +127,16 @@ Community curators, managers, and owners can now lock a request's conversation t
 You can now attach files directly to a comment, with attachments displayed beneath the comment text once submitted.
 
 ![A submitted comment showing an attached file below the comment text](imgs/attached-file-comment.png)
+
+### Community reviews for each record version
+
+Previously, when [submitting a record to a community](../../use/requests.md), only the first version of the record required a review by the community's curators.
+It was not possible to require a review for new versions of the record.
+
+**It is now possible to require a review for all record versions**, subject to custom code on the instance level.
+The default behaviour (where reviews are only required for the initial version) remains unchanged.
+
+See the [requests documentation](../../operate/customize/requests.md#require-reviews-for-each-record-version) for more information.
 
 ### OAuth improvements
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3425

---

I haven't added any end-user documentation, since I don't think the behaviour has really changed. Users will just see a "submit review" button on new record versions for communities where this is configured instead of a "publish" button, which should be relatively self-explanatory. I am happy to add docs for it though if anyone thinks it would help!