### PR TITLE
docs: add and update documentation for ZIP container files

### DIFF
--- a/docs/operate/customize/file-uploads/zip-and-container-files.md
+++ b/docs/operate/customize/file-uploads/zip-and-container-files.md
@@ -2,11 +2,19 @@
 
 _Introduced in v14_
 
-InvenioRDM v14 adds support for ZIP archives as **container files**: record files whose internal structure the
-system understands and can expose. Users can browse the contents of a ZIP directly in the record landing page,
-preview individual files inside the archive, and download specific files or folders without retrieving the entire archive.
+InvenioRDM v14 adds support for ZIP archives as **container files**: record files that the system understands and can expose. You can browse the contents of a ZIP directly on the record landing page, preview individual files inside the archive, and download specific files or directories without retrieving the entire archive.
 
 ![ZIP file preview](../imgs/container-file-formats.png)
+
+## Use cases
+
+This feature is particularly useful for large datasets distributed as archives:
+
+- **Border stones dataset**: A single ZIP holds thousands of images organized in regional subdirectories. Users can browse the tree structure, preview individual images, and download specific pictures or entire directories without downloading the multi-gigabyte archive.
+
+- **Scientific data collections**: Large research datasets (e.g., NetCDF files in the future, simulation outputs) where users need to explore and access specific data files within the logical directory structure.
+
+- **Multi-file publications**: Research materials with numerous supporting documents, figures, or supplementary data that are logically organized but should remain accessible individually.
 
 The feature is designed to be extensible. Additional container formats can be supported by implementing the
 `FileExtractor` interface and registering the handler for the relevant extension. See the
@@ -42,7 +50,7 @@ rather than offering a plain download link.
 
 ## Configuring previews inside archives
 
-A new configuration variable, `CONTAINER_ITEM_PREVIEWER_PREFERENCE`, holds previewers that work for items contained
+A new configuration variable, `PREVIEWER_CONTAINER_ITEM_PREFERENCE`, holds previewers that work for items contained
 inside ZIP files. Currently, all standard previewers except IIIF are supported. IIIF requires additional image server
 links that are not available for container items.
 
@@ -50,7 +58,7 @@ This variable follows the same format as `PREVIEWER_PREFERENCE` but is applied t
 record files.
 
 ```python
-CONTAINER_ITEM_PREVIEWER_PREFERENCE = [
+PREVIEWER_CONTAINER_ITEM_PREFERENCE = [
     "csv_papaparsejs",
     "pdfjs",
     "simple_image",
@@ -67,9 +75,7 @@ CONTAINER_ITEM_PREVIEWER_PREFERENCE = [
 
 ## ZIP processing limits
 
-In invenio-records-resources, new configuration variables have been added to configure ZIP formats and provide defaults
-for ZIP validity checks, maximum listing entries, maximum header size, and extracted-stream chunk size. These are
-checked at upload time.
+The `invenio-records-resources` module provides configuration variables for ZIP formats and safety limits. These limits are checked when you upload a ZIP file:
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
@@ -80,6 +86,7 @@ checked at upload time.
 | `RECORDS_RESOURCES_ZIP_MAX_HEADER_SIZE` | `65536` | Maximum size of the ZIP central directory preloaded into memory, in bytes (64 KB). |
 | `RECORDS_RESOURCES_ZIP_MAX_RATIO` | `200.0` | Maximum allowed compression ratio (uncompressed / compressed size). Protects against ZIP bomb attacks. |
 | `RECORDS_RESOURCES_EXTRACTED_STREAM_CHUNK_SIZE` | `65536` | Chunk size in bytes used when streaming extracted content (64 KB). |
+| `RECORDS_RESOURCES_ARCHIVE_DOWNLOAD_MAX_SIZE` | `None` | Maximum total file size (bytes) for archive download. `None` disables the cap. |
 
 Override any of these in `invenio.cfg`:
 
@@ -92,6 +99,17 @@ RECORDS_RESOURCES_ZIP_MAX_RATIO = 100.0
 RECORDS_RESOURCES_EXTRACTED_STREAM_CHUNK_SIZE = 128 * 1024  # 128 KB
 ```
 
+## Browse ZIP contents in the UI
+
+When you upload a ZIP file and enable the `previewable_zip` previewer, you see:
+
+- **Hierarchical tree view**: A navigation pane showing the directory structure and files inside the archive
+- **Preview buttons**: Individual files can be previewed using the appropriate previewer (images, PDFs, notebooks, etc.)
+- **Download buttons**: Files can be downloaded individually without extracting the entire archive
+- **Directory downloads**: Directories can be downloaded as a new ZIP archive generated on-the-fly
+
+The previewer uses the BroadcastChannel API to communicate between the tree view and the preview iframe for a seamless browsing experience.
+
 ## Supported formats and extensibility
 
 By default, files with extensions listed in the RECORDS_RESOURCES_ZIP_FORMATS configuration (default: [".zip"]) are
@@ -100,3 +118,8 @@ automatically processed as ZIP containers.
 Support for additional container formats can be added by implementing the `FileExtractor` interface in
 `invenio-records-resources` and registering it for the relevant file extension. See the
 [architecture documentation](../../../maintenance/architecture/records.md#container-files) for details.
+
+Future container formats under consideration include:
+- **NetCDF**: For multidimensional scientific data with logical sections
+- **TAR/TAR.GZ**: For general-purpose archive support
+- **WACZ/WARC**: For web archives (already supported via a separate previewer)

--- a/docs/reference/rest_api_drafts_records.md
+++ b/docs/reference/rest_api_drafts_records.md
@@ -1390,11 +1390,22 @@ Last-Modified: Thu, 26 Nov 2020 14:30:06 GMT
 
 _Introduced in v14_
 
-Container files are archive files (e.g., ZIP) whose internal structure InvenioRDM understands. For supported formats, two additional endpoints are available on a published record's files: one to list the archive's contents and one to download individual files or directories from within it.
+Container files are archive files (e.g., ZIP) that InvenioRDM understands. You can browse, preview, and extract individual files from archives without downloading the entire archive. This feature is particularly useful for large datasets organized in directory structures.
 
-#### List the contents of a file
+For supported formats, two additional endpoints are available on a **published record's** files:
+- List the archive contents in a hierarchical tree structure
+- Download or preview individual files and directories from within the archive
+
+!!! note "Published records only"
+    Container file endpoints are available only for **published records**, not drafts. Use `/api/records/{id}/files/` (not `/draft/files/`).
+
+See the [ZIP and container files configuration guide](../operate/customize/file-uploads/zip-and-container-files.md) for setup instructions and supported formats.
+
+#### List the contents of a container file
 
 `GET /api/records/{id}/files/{filename}/container`
+
+List all entries and directories inside a container file. Returns a hierarchical tree structure that can be used to navigate the archive contents.
 
 **Parameters**
 
@@ -1428,11 +1439,11 @@ Content-Type: application/json
       "checksum": "crc:2962613731",
     },
   ],
-  "folders": [
+  "directories": [
     {
       "key": "test_zip",
       "links": {
-        "content": ".../api/records/abc123-yz89/files/demo_with_subfolders.zip/container/test_zip",
+        "content": ".../api/records/abc123-yz89/files/demo_with_subdirectories.zip/container/test_zip",
       },
       "entries": [
         "test_zip/test1.txt",
@@ -1444,13 +1455,61 @@ Content-Type: application/json
 }
 ```
 
-#### Download a container item
+#### List contents of a specific directory
 
 `GET /api/records/{id}/files/{filename}/container/{path}`
 
-Retrieve specific container items from the archive. Enables downloading individual files or groups of files without
-downloading the entire archive. If <path> points to a single container item, the API streams the container item content.
-If <path> points to a container item that is a directory, the API streams a ZIP archive of that directory.
+List the contents of a specific directory inside the container file. The `{path}` parameter specifies the directory path within the archive.
+
+**Parameters**
+
+| Name       | Type   | Location | Description                                                                       |
+| ---------- | ------ | -------- | --------------------------------------------------------------------------------- |
+| `id`       | string | path     | Identifier of the record, e.g. `cbc2k-q9x58`                                     |
+| `filename` | string | path     | Name of a container file, e.g. `dataset.zip`                                     |
+| `path`     | string | path     | Path of the directory inside the archive, e.g. `data/regional/north`                |
+
+**Request**
+
+```http
+GET /api/records/{id}/files/dataset.zip/container/data/regional HTTP/1.1
+```
+
+**Response**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "entries": [
+    {
+      "key": "data/regional/north/images.zip",
+      "size": 1048576,
+      "compressed_size": 524288,
+      "mimetype": "application/zip",
+      "checksum": "crc:1234567890",
+    },
+  ],
+  "directories": [
+    {
+      "key": "data/regional/south",
+      "links": {
+        "content": "/api/records/{id}/files/dataset.zip/container/data/regional/south",
+      },
+      "entries": ["data/regional/south/data.csv"],
+    },
+  ],
+  "total": 1,
+  "truncated": false,
+}
+```
+
+#### Download or preview a container item
+
+`GET /api/records/{id}/files/{filename}/container/{path}`
+
+Retrieve specific container items from the archive. This endpoint supports both downloading and previewing files inside the archive. When used with a file path, it streams the file content directly. When used with a directory path, it generates a ZIP archive of the directory contents on-the-fly.
 
 **Parameters**
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -142,12 +142,12 @@ PREVIEWER_PREFERENCE = [
 ]
 ```
 
-`CONTAINER_ITEM_PREVIEWER_PREFERENCE` controls which previewers are tried for files *inside* an archive.
+`PREVIEWER_CONTAINER_ITEM_PREFERENCE` controls which previewers are tried for files *inside* an archive.
 It follows the same format as `PREVIEWER_PREFERENCE` but IIIF is excluded, since it requires additional image server
 links that are not available for container items:
 
 ```python
-CONTAINER_ITEM_PREVIEWER_PREFERENCE = [
+PREVIEWER_CONTAINER_ITEM_PREFERENCE = [
     "csv_papaparsejs",
     "pdfjs",
     "simple_image",

--- a/docs/releases/v14/version-v14.0.md
+++ b/docs/releases/v14/version-v14.0.md
@@ -168,7 +168,7 @@ These new features allow:
 
 - Previewing files inside ZIPs (images, PDFs, text, notebooks, audio/video, etc.)
 
-- Downloading individual files or folders without extracting the entire archive
+- Downloading individual files or directories without extracting the entire archive
 
 ![ZIP file preview](imgs/container-file-formats.png)
 

--- a/docs/use/records.md
+++ b/docs/use/records.md
@@ -156,3 +156,45 @@ Find below the `Accept` header MIME type for each export format.
 | [BibTex](https://www.bibtex.com/format/)                                                                                                          | `application/x-bibtex`                    |
 | [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dces/)                                                                        | `application/x-dc+xml`                    |
 | [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)                                                                                          | `application/vnd.geojson+json`            |
+
+## Container files (ZIP archives)
+
+_Introduced in v14_
+
+InvenioRDM supports ZIP files as **container files**. You can browse, preview, and download individual files from within archives without downloading the entire archive.
+
+### How it works
+
+When you upload a ZIP file to a record:
+
+1. **Tree view navigation**: The record landing page displays a hierarchical tree view of the ZIP contents
+2. **Individual file preview**: Click any file to preview it using the appropriate previewer (images, PDFs, notebooks, etc.)
+3. **Selective downloading**: Download specific files or directories without extracting the entire archive
+4. **Directory downloads**: Directories are downloaded as on-the-fly generated ZIP archives
+
+![ZIP file preview](../operate/customize/imgs/container-file-formats.png)
+
+### Use cases
+
+- **Large datasets**: Share thousands of files organized in directories without requiring users to download everything
+- **Research data**: Allow researchers to explore and select specific data files from complex dataset structures  
+- **Multi-file publications**: Provide easy access to supplementary materials, figures, and supporting documents
+
+### Enable container file browsing
+
+To enable container file browsing for your instance, do the following:
+
+1. Replace the standard `zip` previewer with `previewable_zip` in the configuration
+2. Optionally configure `PREVIEWER_CONTAINER_ITEM_PREFERENCE` to control which previewers work inside archives
+3. Adjust ZIP processing limits if needed for your use case
+
+See the [ZIP and container files configuration guide](../operate/customize/file-uploads/zip-and-container-files.md) for detailed setup instructions.
+
+### API access
+
+Container files can also be accessed programmatically via the REST API:
+
+- List archive contents: `GET /api/records/{id}/files/{filename}/container`
+- Download individual items: `GET /api/records/{id}/files/{filename}/container/{path}`
+
+See the [REST API reference](../reference/rest_api_drafts_records.md#container-files) for details.


### PR DESCRIPTION
### Description

Updates documentation for the ZIP container files feature introduced in v14

This PR adds comprehensive documentation for the ZIP container files feature, allowing users to browse, preview, and download individual files from ZIP archives without extracting the entire archive.

What's new
User guide: Added section on container files in docs/use/records.md explaining the feature from a user perspective
Configuration guide: Updated zip-and-container-files.md with correct configuration variable names and all available options
API reference: Updated REST API documentation with correct endpoint paths (/files/<key>/container)
Terminology: Standardized to use "directories" instead of "folders" throughout

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
