### PR TITLE
most up-to-date upgrade notes

### DIFF
--- a/docs/community/code/prerelease-instance-development.md
+++ b/docs/community/code/prerelease-instance-development.md
@@ -76,15 +76,31 @@ instance permanently. For example, you might have a local identifier scheme that
 you want [idutils](https://github.com/inveniosoftware/idutils)
 to verify. It wouldn't be appropriate to make a pull request, since this
 change is only relevant to your organization. You can make your fork available on GitHub
-and add the following to your Pipfile:
+and add the following to your project file (by default `pyproject.toml` in v14+ InvenioRDM, `Pipfile` before):
 
-```toml
-[packages]
-idutils = {git = "https://github.com/your-username/idutils.git", ref = "main"}
-```
+=== "pyproject.toml"
 
-You will need to update your `Pipfile.lock` after this kind of change. Run
-`pipenv lock` or `invenio-cli install`.
+    ```toml
+    [project]
+
+    dependencies = [
+        # ...
+        "idutils",
+    ]
+
+    [tool.uv.sources]
+    idutils = { git = "https://github.com/your-username/idutils.git", branch = "main" }
+    ```
+
+=== "Pipfile"
+
+    ```ini
+    [packages]
+    idutils = {git = "https://github.com/your-username/idutils.git", ref = "main"}
+    ```
+
+You will need to update your lock file after this kind of change. Run
+`invenio-cli packages lock`.
 
 !!! warning
     It's not recommended to do this with invenio packages that change often,

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,6 @@ hide:
 template: frontpage.html
 ---
 
-!!! tip "July 23rd, 2025: InvenioRDM v13.0 available! ✨"
+!!! tip "MONTH DAY, 2026: InvenioRDM v14.0 available! 🌠"
 
-    🚀 Read the full [release notes](releases/v13/version-v13.0.0.md).
+    🚀 Read the full [release notes](releases/v14/version-v14.0.md).

--- a/docs/install/build-setup-run.md
+++ b/docs/install/build-setup-run.md
@@ -4,7 +4,7 @@ Now that we have created a project folder, we need to build and set up the Inven
 
 As mentioned before, the application can be built and installed in two different ways:
 
-- *Local development* (good for developers or for customizing your instance): The application is installed directly on your machine in a Python [virtual environment](../reference/virtualenvs.md) managed by the ``pipenv`` tool (its services are containerized though).
+- *Local development* (good for developers or for customizing your instance): The application is installed directly on your machine in a Python [virtual environment](../reference/virtualenvs.md) managed by the python package manager tool (by default ``uv``). Its services are containerized though.
 - *Containerized preview* (good for quick preview): The application is built inside a Docker image and, it, along with the services are all containerized.
 
 ## Condensed version
@@ -48,30 +48,11 @@ invenio-cli packages lock
 ```console
 Locking dependencies... Allow pre-releases: False. Include dev-packages: False.
 Locking python dependencies...
-Creating a virtualenv for this project…
-Pipfile: /Users/johnsmith/src/tmp/my-site/Pipfile
-Using /Users/johnsmith/.virtualenvs/cli/bin/python3.8 (3.8.5) to create virtualenv…
-⠇ Creating virtual environment...created virtual environment CPython3.8.5.final.0-64 in 542ms
-  creator CPython3Posix(dest=/Users/johnsmith/.virtualenvs/my-site-0wtHqD1g, clear=False, global=False)
-  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/johnsmith/Library/Application Support/virtualenv)
-    added seed packages: pip==21.0.1, setuptools==53.1.0, wheel==0.36.2
-  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
-
-✔ Successfully created virtual environment!
-Virtualenv location: /Users/johnsmith/.virtualenvs/my-site-0wtHqD1g
-Locking [dev-packages] dependencies…
-Building requirements...
-Resolving dependencies...
-✔ Success!
-Locking [packages] dependencies…
-Building requirements...
-Resolving dependencies...
-✔ Success!
-Updated Pipfile.lock (271a6d)!
+[...]
 Dependencies locked successfully.
 ```
 
-A new file ``Pipfile.lock`` has now been created with the locked dependencies.
+A new lock file (e.g., ``uv.lock``) has now been created with the locked dependencies.
 
 Next, follow the *local development* option or *containerized preview* option according to your preferred installation method.
 
@@ -88,19 +69,14 @@ invenio-cli install
 ```
 ```console
 Installing python dependencies... Please be patient, this operation might take some time...
-Installing dependencies from Pipfile.lock (271a6d)…
-  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 200/200 — 00:02:00
-
 [...]
-
 Built webpack project.
-Assets and statics updated.
 Dependencies installed successfully.
 ```
 
 The command does the following:
 
-- Install Python dependencies (according the ``Pipfile.lock``)
+- Install Python dependencies (according to the lock file)
 - Install JavaScript dependencies
 - Build the JavaScript/CSS web assets
 
@@ -194,7 +170,7 @@ The command will:
 
 - Download the Docker images for the services (database, cache, search engine, etc.)
 - Build the Docker image for the InvenioRDM application using the ``Dockerfile`` in your project.
-- Install Python dependencies (according the ``Pipfile.lock``)
+- Install Python dependencies (according to the lock file)
 - Install JavaScript dependencies
 - Build the JavaScript/CSS web assets
 
@@ -265,7 +241,3 @@ Go and explore your InvenioRDM instance at [https://127.0.0.1](https://127.0.0.1
 
 - You may see the following error message `TypeError: Object.fromEntries is not a function`.
   This means you need to update your base Invenio docker image because Node.js 14+ is needed. Make sure the base Invenio image is up to date. You can re-build your instance image with `invenio-cli containers build --pull --no-cache` to make sure things are done from scratch.
-- You may see `SystemError: Parent module 'setuptools' not loaded, cannot perform relative import`
-  at the dependency locking step when running `invenio-cli containers start`. This depends on your version of `setuptools` (bleeding edge causes this)
-  and can be solved by setting an environment variable: `SETUPTOOLS_USE_DISTUTILS=stdlib`. [See more details](https://github.com/pypa/setuptools/blob/17cb9d6bf249cefe653d3bdb712582409035a7db/CHANGES.rst#v5000). This sudden upstream change will be addressed more systematically in future releases.
-- You may see the following error message  ``pkg_resources.ContextualVersionConflict: (setuptools 60.5.0 (...), Requirement.parse('setuptools<59.7.0,>=59.1.1'), {'celery'})`` when running ``invenio-cli install``. This happens when you recently installed or upgraded ``invenio-cli``. The problem can be fixed by adding ``setuptools = ">=59.1.1,<59.7.0"`` to the ``[dev-packages]`` section in your ``Pipfile``. The problem happens when virtualenv v20.13.1+ gets installed with Invenio-CLI and when Celery v5.2.3 gets is installed with InvenioRDM. Only Celery v5.2.3 causes this issue.

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -6,16 +6,16 @@ InvenioRDM is set up with a command line management tool, `invenio-cli`, which i
 
 `invenio-cli` is available on [PyPI](https://pypi.org/project/invenio-cli/). Use your favorite way to install it:
 
-=== "pip"
-
-    ```shell
-    pip install invenio-cli
-    ```
-
 === "uv"
 
     ```shell
     uv tool install invenio-cli
+    ```
+
+=== "pip"
+
+    ```shell
+    pip install invenio-cli
     ```
 
 === "pipx"

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -33,16 +33,16 @@ Here is the most succinct outline of the steps to take to get started whether yo
 
 Irrespective of *preview* or *development* installation, you will need this command line tool:
 
-=== "pip"
-
-    ```shell
-    pip install invenio-cli
-    ```
-
 === "uv"
 
     ```shell
     uv tool install invenio-cli
+    ```
+
+=== "pip"
+
+    ```shell
+    pip install invenio-cli
     ```
 
 === "pipx"

--- a/docs/install/initialize.md
+++ b/docs/install/initialize.md
@@ -19,11 +19,10 @@ The CLI will require the following data:
 - **Author name**: Your name or that of your organization
 - **Author email**: Email for communication
 - **Year**: The current year
-- **Database**: PostgreSQL (default)
-- **Search**: OpenSearch 2 (default)
 - **Storage backend**: Local file system (default) or in a S3-like backend. If S3 is chosen a MinIO container is provided.
 - **Development tools**: `Yes` if you want to add extra development tools (e.g. OpenSearch Dashboard) to your instance.
 - **Site code**: `Yes` if you want to add custom code to your instance.
+- **Base image**: The base Invenio image derived from a specific OS to use.
 - **Reduced vocabularies**: `Yes` builds a full set of language, license and name vocabularies. `No` uses a reduced set for faster setup.
 
 It will also generate a test private key which is needed for SSL support in the development server.
@@ -46,41 +45,36 @@ Let's do it! Pressing `[Enter]` selects the default option in brackets `[]`.
     invenio-cli init rdm -c master
     ```
 
-The current InvenioRDM release (for production systems) is ``v12.0``
 
 ```console
 Initializing RDM application...
 Running cookiecutter...
-project_name [My Site]:
-project_shortname [my-site]:
-package_name [my_site]:
-project_site [my-site.com]:
-author_name [CERN]:
-author_email [info@my-site.com]:
-year [2023]:
-Choose from 1 [1]:
-Select database:
-1 - postgresql
-Choose from 1 [1]:
-Select search:
-1 - opensearch2
-Choose from 1, 2 [1]:
-Select file_storage:
-1 - local
-2 - S3
-Choose from 1, 2 [1]:
-Select development_tools:
-1 - yes
-2 - no
-Choose from 1, 2 [1]:
-Select site_code:
-1 - yes
-2 - no
-Choose from 1, 2 [1]:
-Select use_reduced_vocabs:
-1 - no
-2 - yes
-Choose from 1, 2 [1]:
+  [1/12] project_name (My Site):
+  [2/12] project_shortname (my-site):
+  [3/12] package_name (my_site):
+  [4/12] project_site (my-site.com):
+  [5/12] author_name (CERN):
+  [6/12] author_email (info@my-v14-2026-07-21-site.com):
+  [7/12] year (2026):
+  [8/12] Select file_storage
+    1 - local
+    2 - S3
+    Choose from [1/2] (1):
+  [9/12] Select development_tools
+    1 - yes
+    2 - no
+    Choose from [1/2] (1):
+  [10/12] Select site_code
+    1 - yes
+    2 - no
+    Choose from [1/2] (1): 2
+  [11/12] Select base_image
+    1 - debian
+    Choose from [1] (1):
+  [12/12] Select use_reduced_vocabs
+    1 - yes
+    2 - no
+    Choose from [1/2] (1): 2
 ```
 
 ## Project structure
@@ -100,7 +94,7 @@ ls -a1
 .invenio
 .invenio.private
 Dockerfile
-Pipfile
+pyproject.toml
 README.md
 app_data
 assets
@@ -119,7 +113,7 @@ Following is an overview of the generated files and folders:
 | Name | Description |
 |---|---|
 | ``Dockerfile`` | Dockerfile used to build your application image. |
-| ``Pipfile`` | Python requirements installed via [pipenv](https://pipenv.pypa.io) |
+| ``pyproject.toml`` | Python project file setup via [uv](https://pipenv.pypa.io) |
 | ``app_data/`` | Application data for e.g. vocabularies. |
 | ``assets/`` | Web assets (CSS, JavaScript, LESS, JSX templates) used in the Webpack build. |
 | ``docker/`` | Example configuration for NGINX and uWSGI for running InvenioRDM. |

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -5,7 +5,7 @@
 InvenioRDM depends on the following requirements to be installed on your local system:
 
 - MacOS or Linux-based systems (Windows systems is not supported).
-- [Python](https://www.python.org/) 3.9 / 3.11 / 3.12 and [pip](https://pip.pypa.io/en/stable/)
+- [Python](https://www.python.org/) 3.14 recommended ; 3.11, 3.12, 3.13 possible and [pip](https://pip.pypa.io/en/stable/)
     - Python development headers:
         - On Ubuntu: `sudo apt install python3-dev`.
         - On RHEL/Fedora: `yum install -y python3-devel.x86_64`.
@@ -22,7 +22,7 @@ InvenioRDM depends on the following requirements to be installed on your local s
 For running and building the application locally you will also need:
 
 - [Git](https://git-scm.com/).
-- [Node.js](https://nodejs.org) 24.0+ and corresponding `npm`. InvenioRDM also works with version 26.0+. We recommend that you install Node through [nvm](https://github.com/nvm-sh/nvm) (e.g. `nvm install --lts`) or [equivalent](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+- [Node.js](https://nodejs.org) 24 recommended (22 and 26 possible) and corresponding `npm`. We recommend that you install Node through [nvm](https://github.com/nvm-sh/nvm) (e.g. `nvm install --lts`) or [equivalent](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 - [Cairo](https://invenio-formatter.readthedocs.io/en/latest/installation.html) needed for badges to be properly displayed.
 - [DejaVu Fonts](https://dejavu-fonts.github.io/Download.html) needed for badges rendering.
 - [ImageMagick](https://imagemagick.org/script/download.php) needed for IIIF file rendering.
@@ -53,7 +53,7 @@ InvenioRDM runs on machines that have at least 8GB of RAM and at least 4 cores.
 
 ## Python packages
 
-Because we want to avoid cluttering the Python packages of the system or user with InvenioRDM dependencies, `invenio-cli` uses virtual environments. This is done by interacting with `pipenv` behind the scenes.
+Because we want to avoid cluttering the Python packages of the system or user with InvenioRDM dependencies, `invenio-cli` uses virtual environments. This is done by interacting with your selected python package manager (`uv` or `pipenv`) behind the scenes.
 
 To use a different Python version in the virtual environment than the one installed globally, a Python version manager such as `pyenv` or `asdf` with `asdf-python` or `mise` is required.
 

--- a/docs/install/stop.md
+++ b/docs/install/stop.md
@@ -41,7 +41,7 @@ Note that `destroy` will also `stop` the containers, so there is no need to run 
 
 ## Destroy everything
 
-If you want to also destroy any ``pipenv``-managed Python virtual environment, you can use the global `destroy command`. This command is the same for both installation options and wipes everything but your project files:
+If you want to wipe everything (virtual environment, containers, data...) EXCEPT your project files (all files setup by cookiecutter), you can use the global `destroy command`. This command is the same for both installation options:
 
 ```bash
 invenio-cli destroy

--- a/docs/install/troubleshoot.md
+++ b/docs/install/troubleshoot.md
@@ -17,12 +17,28 @@ pkg_resources.DistributionNotFound: The 'greenlet!=0.4.17; python_version >= "3"
 ```
 
 In order to solve it, a common workaround consists in installing the `sqlalchemy[asyncio]` package which brings in the correct dependencies.
-As such, you should add the following line inside your `Pipfile`:
+As such, you should add the following line inside your project file:
 
-```python
-sqlalchemy = {version = "*", extras = ["asyncio"]}
-```
-in the `[packages]` section.
+=== "pyproject.toml"
+
+    ```ini
+    [project]
+
+    dependencies = [
+        # ...
+        "sqlalchemy[asyncio]",
+    ]
+    ```
+
+=== "Pipfile"
+
+    ```ini
+    [packages]
+    # ...
+    sqlalchemy = {version = "*", extras = ["asyncio"]}
+    ```
+
+
 
 ## Getting help
 

--- a/docs/maintenance/internals/administration_panel.md
+++ b/docs/maintenance/internals/administration_panel.md
@@ -246,16 +246,28 @@ To register your new view, you will have to:
 
 In OAI-PMH sets example, views are registered in `Invenio-Administration` as individual entry points from `invenio-rdm-records`.
 
-Edit the setup.cfg in the module and add:
+Edit the project file in the module and add:
 
-```ini
-[options.entry_points]
-invenio_administration.views =
-    invenio_rdm_records_oai_list = invenio_rdm_records.administration.views.oai:OaiPmhListView
-    invenio_rdm_records_oai_edit = invenio_rdm_records.administration.views.oai:OaiPmhEditView
-    invenio_rdm_records_oai_create = invenio_rdm_records.administration.views.oai:OaiPmhCreateView
-    invenio_rdm_records_details = invenio_rdm_records.administration.views.oai:OaiPmhDetailView
-```
+=== "pyproject.toml"
+
+    ```toml
+    [project.entry-points."invenio_administration.views"]
+    invenio_rdm_records_oai_list = "invenio_rdm_records.administration.views.oai:OaiPmhListView"
+    invenio_rdm_records_oai_edit = "invenio_rdm_records.administration.views.oai:OaiPmhEditView"
+    invenio_rdm_records_oai_create = "invenio_rdm_records.administration.views.oai:OaiPmhCreateView"
+    invenio_rdm_records_details = "invenio_rdm_records.administration.views.oai:OaiPmhDetailView"
+    ```
+
+=== "setup.cfg"
+
+    ```ini
+    [options.entry_points]
+    invenio_administration.views =
+        invenio_rdm_records_oai_list = invenio_rdm_records.administration.views.oai:OaiPmhListView
+        invenio_rdm_records_oai_edit = invenio_rdm_records.administration.views.oai:OaiPmhEditView
+        invenio_rdm_records_oai_create = invenio_rdm_records.administration.views.oai:OaiPmhCreateView
+        invenio_rdm_records_details = invenio_rdm_records.administration.views.oai:OaiPmhDetailView
+    ```
 
 #### Create custom view
 
@@ -281,13 +293,22 @@ class MyCustomView(AdminView):
 
 The class defined for the custom view must be registered as an entry point, as follows:
 
-Edit the `setup.cfg` of your module and add:
+Edit the project file of your module and add:
 
-```ini
-[options.entry_points]
-invenio_administration.views =
-    invenio_module_admin_custom_view = invenio_module.path.to.filename:MyCustomView
-```
+=== "pyproject.toml"
+
+    ```toml
+    [project.entry-points."invenio_administration.views"]
+    invenio_module_admin_custom_view = "invenio_module.path.to.filename:MyCustomView"
+    ```
+
+=== "setup.cfg"
+
+    ```ini
+    [options.entry_points]
+    invenio_administration.views =
+        invenio_module_admin_custom_view = invenio_module.path.to.filename:MyCustomView
+    ```
 
 For the full attributes list and description visit the [reference docs](./administration_reference.md)
 
@@ -428,19 +449,20 @@ There are two ways to grant this permission:
     ```bash
       # make sure you are inside your instance's directory
       cd my-site
+      # precede the invenio commands by `uv run` or `pipenv run` as appropriate
       # Create a role named administration
-      pipenv run invenio roles create administration
+      invenio roles create administration
       # Allow access to administration to the administration role
-      pipenv run invenio access allow administration-access role administration
+      invenio access allow administration-access role administration
       # Add administration role to an user email
-      pipenv run invenio roles add <user_email> administration
+      invenio roles add <user_email> administration
     ```
 
-2. Permission can be added to a specific user:
+2. Permission can be added to a specific user (precede by `uv run` or `pipenv run` as appropriate):
 
     ```bash
       # Grant access to a specific user to the action administration-access
-      pipenv run invenio access allow administration-access user <user_email>
+      invenio access allow administration-access user <user_email>
     ```
 
 ### Admin actions permissions

--- a/docs/maintenance/internals/extensions.md
+++ b/docs/maintenance/internals/extensions.md
@@ -113,12 +113,12 @@ cd path/to/your/instance
 invenio-cli packages install path/to/your/extension
 ```
 
-When you are ready to go in production, add the extension to your Pipfile e.g. `pipenv install my-subjects-extension` if you've open-sourced it. The command `invenio-cli packages install path/to/your/extension` doesn't add it to your Pipfile as of writing.
+When you are ready to go in production, add the extension to your project file e.g. `uv add my-subjects-extension` (or `pipenv install my-subjects-extension`) if you've open-sourced it. The command `invenio-cli packages install path/to/your/extension` doesn't add it to your project file (`pyproject.toml` or `Pipfile`) as of writing.
 
-For controlled vocabulary extensions like ours, we need to load the terms in the database and Elasticsearch to see them. Run at the top-level of your instance directory:
+For controlled vocabulary extensions like ours, we need to load the terms in the database and Elasticsearch to see them. Run at the top-level of your instance directory (precede by `uv run` or `pipenv run` as appropriate):
 
 ```
-pipenv run invenio rdm-records fixtures
+invenio rdm-records fixtures
 ```
 
 This will load all new controlled vocabularies not already present in your database. This process actually queues the loading for

--- a/docs/maintenance/operations/demosite.md
+++ b/docs/maintenance/operations/demosite.md
@@ -22,7 +22,7 @@ For example, if transitioning from InvenioRDM v6 to v7, then you would follow th
 Code is on GitHub: [demo-inveniordm](https://github.com/inveniosoftware/demo-inveniordm).
 
 !!! warning
-    To lock the Pipenv file, **you need to have the Python version of the Docker file on your machine**.
+    To generate the lock file, **you need to have the same Python version as the Dockerfile one on your machine**.
     No other versions will work. Other Python version might install some Python packages that are not compatible.
 
 1. Clone and make a local install of the code
@@ -37,9 +37,9 @@ Code is on GitHub: [demo-inveniordm](https://github.com/inveniosoftware/demo-inv
    invenio-cli packages update 7.0.0
    ```
 
-2. Create a PR with the needed changes. If you change `Pipenv` dependencies, make sure that you also add the
-   new `Pipfile.lock` file. To do so, locally in your machine, delete the previous .lock file and run
-   `pipenv lock`. Note: This PR should not be the release PR as this would create a tag, the release PR
+2. Create a PR with the needed changes. If you change Python dependencies, make sure that you also add the
+   new lock file. To do so, locally in your machine, delete the previous .lock file and run
+   `uv lock`. Note: This PR should not be the release PR as this would create a tag, the release PR
    is only created when upgrading the production site.
 3. You can test such changes locally: the demo site is an InvenioRDM instance and thus can be used in your
    local machine with the usual *invenio-cli* commands.

--- a/docs/operate/code/custom_code.md
+++ b/docs/operate/code/custom_code.md
@@ -19,13 +19,28 @@ Select site_code:
 Choose from 1, 2 [1]:
 ```
 
-To generate the site folder, you will need to select option `1 - yes` (this is already the default option). Now, after the bootstrapping is finished, you can see a folder named "site" in the root folder of your instance, as well as the following line in your instance folder's Pipfile:
+To generate the site folder, you will need to select option `1 - yes` (this is already the default option). Now, after the bootstrapping is finished, you can see a folder named "site" in the root folder of your instance, as well as the following line in your instance folder's project file:
 
-```python hl_lines="3"
-[packages]
-...
-my-site = {editable=true, path="./site"}
-```
+=== "pyproject.toml"
+
+    ```toml
+    [project]
+
+    dependencies = [
+        # ...
+        "my-site",
+    ]
+
+    [tool.uv.sources]
+    my-site = { path: "./site", editable = true }
+    ```
+
+=== "Pipfile"
+
+    ```ini hl_lines="3"
+    [packages]
+    my-site = {editable=true, path="./site"}
+    ```
 
 This means that the site folder will be installed as a package with the name `my-site`, and it is editable. This package now works as any other package installed in your instance (`invenio-app-rdm`, `invenio-communities`, etc.), allowing you to customize your instance and create new views and features without adding a separate package manually.
 

--- a/docs/operate/code/debugging.md
+++ b/docs/operate/code/debugging.md
@@ -17,7 +17,8 @@ You can also install [Flask-DebugToolbar](https://flask-debugtoolbar.readthedocs
 
 ```shell
 cd ~/src/my-site
-pipenv run pip install Flask-Debugtoolbar
+# precede by `uv run` or `pipenv run` as appropriate
+pip install Flask-Debugtoolbar
 ```
 
 It has built-in:

--- a/docs/operate/customize/authentication.md
+++ b/docs/operate/customize/authentication.md
@@ -728,10 +728,19 @@ data between two parties: an identity provider (IdP) and a service provider (SP)
 
 * Make sure you have installed the required Invenio Python module:
 
-    ```console
-    cd my-site
-    pipenv run pip install invenio-saml
-    ```
+    === "uv"
+
+        ```shell
+        cd my-site
+        uv add invenio-saml
+        ```
+
+    === "pipenv"
+
+        ```shell
+        cd my-site
+        pipenv install invenio-saml
+        ```
 
 #### Server information
 

--- a/docs/operate/customize/dnb_urns.md
+++ b/docs/operate/customize/dnb_urns.md
@@ -12,6 +12,15 @@ If you're interested in the source code, you will find it [here](https://github.
 
 The module implements a thin wrapper around the [Rest-API](https://wiki.dnb.de/display/URNSERVDOK/URN-Service+API) provided by the DNB (German national library) and enhances InvenioRDM with URN minting support. New is the support of versioning: the first versions URN automatically forwards to the most actual version.
 
+=== "pyproject.toml"
+
+    ```diff
+    dependencies = [
+    ...
+    +   "invenio-pidstore-extra>=0.2.0,<1.0.0",
+    ]
+    ```
+
 === "Pipfile"
 
     ```diff
@@ -20,24 +29,7 @@ The module implements a thin wrapper around the [Rest-API](https://wiki.dnb.de/d
     + invenio-pidstore-extra = ">=0.2.0,<1.0.0"
     ```
 
-=== "pyproject.toml"
-
-    ```diff
-    dependencies = [
-    ...
-    +   "invenio-pidstore-extra >= 0.2.0,<1.0.0",
-    ]
-    ```
-
-
-And next:
-
-=== "pip"
-
-    ```shell
-    rm -f Pipfile.lock
-    invenio-cli install
-    ```
+And next, run the following commands:
 
 === "uv"
 
@@ -45,6 +37,14 @@ And next:
     rm -f uv.lock
     invenio-cli install
     ```
+
+=== "pipenv"
+
+    ```shell
+    rm -f Pipfile.lock
+    invenio-cli install
+    ```
+
 
 ## Configure the DNB URN PID provider
 
@@ -75,8 +75,8 @@ When putting this to production, set `PIDSTORE_EXTRA_TEST_MODE = False`!
 +   RDM_PERSISTENT_IDENTIFIER_PROVIDERS = DEFAULT_PERSISTENT_IDENTIFIER_PROVIDERS + [
 +       providers.DnbUrnProvider(
 +         "urn",
-+         client=providers.DNBUrnClient("dnb", PIDSTORE_EXTRA_DNB_ID_PREFIX, 
-+         PIDSTORE_EXTRA_DNB_USERNAME, PIDSTORE_EXTRA_DNB_PASSWORD, 
++         client=providers.DNBUrnClient("dnb", PIDSTORE_EXTRA_DNB_ID_PREFIX,
++         PIDSTORE_EXTRA_DNB_USERNAME, PIDSTORE_EXTRA_DNB_PASSWORD,
 +         PIDSTORE_EXTRA_FORMAT),
 +         label=_("URN"),
 +       ),
@@ -97,7 +97,7 @@ When putting this to production, set `PIDSTORE_EXTRA_TEST_MODE = False`!
 +   from invenio_pidstore_extra.services.components import URNRelationsComponent
 +   from invenio_rdm_records.services.components import DefaultRecordsComponents
 
-+   RDM_RECORDS_SERVICE_COMPONENTS = DefaultRecordsComponents + 
++   RDM_RECORDS_SERVICE_COMPONENTS = DefaultRecordsComponents +
 +   [URNRelationsComponent]
 
 ```

--- a/docs/operate/customize/file-uploads/s3.md
+++ b/docs/operate/customize/file-uploads/s3.md
@@ -18,7 +18,7 @@ After having setup your MinIO application, you can review the settings below.
 ### Bucket and data location
 A default bucket (`default`) is created automatically in your MinIO container. This bucket will be used as the default files' location for your InvenioRDM instance if you choose `s3` as file storage during project initialization.
 
-If you want to change the bucket name, open a shell window and type `pipenv run invenio files location s3-default s3://new-bucket --default`. You will also need to manually create the new bucket in MinIO or your S3 storage system. The new bucket will only be used for new records or drafts (existing drafts and records will use `default`).
+If you want to change the bucket name, open a shell window and type `invenio files location s3-default s3://new-bucket --default` (preceded by `uv run` or `pipenv run` as appropriate). You will also need to manually create the new bucket in MinIO or your S3 storage system. The new bucket will only be used for new records or drafts (existing drafts and records will use `default`).
 
 ### Credentials
 The last step is to set your credentials so your instance can authenticate against the S3 container.
@@ -66,5 +66,4 @@ S3_CONFIG_EXTRA = {
         "request_checksum_calculation": "WHEN_REQUIRED",
         "response_checksum_validation": "WHEN_REQUIRED",
     }
-```
 ```

--- a/docs/operate/customize/jobs.md
+++ b/docs/operate/customize/jobs.md
@@ -9,7 +9,7 @@ A job is a wrapper around a `Celery` task that can be scheduled, run on demand, 
 The Invenio job system uses a custom Celery task scheduler which requires a separate Celery beat. You can run the custom beat in a separate container or shell like so:
 
 ```bash
-celery -A invenio_app.celery beat -l INFO --scheduler invenio_jobs.services.scheduler:RunScheduler 
+celery -A invenio_app.celery beat -l INFO --scheduler invenio_jobs.services.scheduler:RunScheduler
 ```
 
 The `-l INFO` flag sets the logging level to `INFO`. You can adjust the logging level (e.g., `DEBUG`, `WARNING`, `ERROR`) based on your needs, and the logs will reflect the level you set.
@@ -103,19 +103,33 @@ class UpdateEmbargoesJob(JobType):
 
 ### 3. Register Your Job and Task
 
-In your `setup.cfg`, register the task and job using entry points:
+In your project file, register the task and job using entry points:
 
-```ini
-[options.entry_points]
-invenio_celery.tasks =
-    mysite_tasks = mysite.tasks
 
-invenio_jobs.jobs =
-    update_expired_embargoes = mysite.jobs:UpdateEmbargoesJob
-```
+=== "pyproject.toml"
+
+    ```toml
+    [project.entry-points."invenio_celery.tasks"]
+    mysite_tasks = "mysite.tasks"
+
+    [project.entry-points."invenio_jobs.jobs"]
+    update_expired_embargoes = "mysite.jobs:UpdateEmbargoesJob"
+    ```
+
+=== "setup.cfg"
+
+    ```ini
+    [options.entry_points]
+    invenio_celery.tasks =
+        mysite_tasks = mysite.tasks
+
+    invenio_jobs.jobs =
+        update_expired_embargoes = mysite.jobs:UpdateEmbargoesJob
+    ```
+
 !!! tip
 
-    **Note (local development only):** If you're developing locally and have modified `setup.cfg`, remember to re-run `pipenv run pip install -e ./site` so that entry point changes take effect.
+    **Note (local development only):** If you're developing locally and have modified `pyproject.toml`/`setup.cfg`, remember to re-run `pip install -e ./site` (preceded by `uv run` or `pipenv run` as appropriate) so that entry point changes take effect.
 
 ### 4. Run and Monitor Jobs
 

--- a/docs/operate/customize/look-and-feel/templates.md
+++ b/docs/operate/customize/look-and-feel/templates.md
@@ -91,10 +91,10 @@ We will simply change the content to the following as an example:
 
 !!! info "Side-note: How to find routes"
 
-    To find the value to use in `url_for`, you can list InvenioRDM's routes via this command:
+    To find the value to use in `url_for`, you can list InvenioRDM's routes via this command (preceded by `uv run` or `pipenv run` as appropriate):
 
     ```shell
-    pipenv run invenio routes
+    invenio routes
     ```
 
 **Step 2** - Restart your server

--- a/docs/operate/customize/metadata/custom_fields/communities.md
+++ b/docs/operate/customize/metadata/custom_fields/communities.md
@@ -54,7 +54,8 @@ make them searchable. The only difference is the CLI command:
 cd my-site
 
 # initialize all custom fields to make them searchable
-pipenv run invenio communities custom-fields init
+# precede by `uv run` or `pipenv run` as appropriate
+invenio communities custom-fields init
 ```
 
 ## Displaying fields

--- a/docs/operate/customize/metadata/custom_fields/custom_fields.md
+++ b/docs/operate/customize/metadata/custom_fields/custom_fields.md
@@ -215,8 +215,8 @@ Custom field initialization, in a new shell run:
 
 ```bash
 $ cd my-site
-
-$ pipenv run invenio rdm-records custom-fields init -f experiments
+$ # precede by `uv run` or `pipenv run` as appropriate
+$ invenio rdm-records custom-fields init -f experiments
 ```
 
 ## See it in action

--- a/docs/operate/customize/metadata/custom_fields/records.md
+++ b/docs/operate/customize/metadata/custom_fields/records.md
@@ -74,10 +74,10 @@ For our example, you'll then want to make a file `app_data/vocabularies/cern_exp
 {"id": "LHC", "title": {"en": "Large Hadron Collider"}}
 ```
 
-If you've already set up your services, you can create this vocabulary with
+If you've already set up your services, you can create this vocabulary with (precede by `uv run` or `pipenv run` as appropriate)
 
-```
-pipenv run invenio rdm-records fixtures
+```bash
+invenio rdm-records fixtures
 ```
 
 You can see then see the vocabulary at `/api/vocabularies/cernexperiments`
@@ -126,16 +126,17 @@ In a shell, run:
 
 ```bash
 cd my-site
-
 # initialize all custom fields to make them searchable
-pipenv run invenio rdm-records custom-fields init
+# precede by `uv run` or `pipenv run` as appropriate
+invenio rdm-records custom-fields init
 ```
 
 When you want to make a new specific field searchable:
 
 ```bash
 # initialize specific custom fields to make them searchable
-pipenv run invenio rdm-records custom-fields init -f cern:experiment -f <field_name>
+# precede by `uv run` or `pipenv run` as appropriate
+invenio rdm-records custom-fields init -f cern:experiment -f <field_name>
 ```
 
 !!! tip

--- a/docs/operate/customize/metadata/optional_fields.md
+++ b/docs/operate/customize/metadata/optional_fields.md
@@ -45,7 +45,7 @@ RDM_CUSTOM_FIELDS_UI = [
 ]
 ```
 
-You'll need to initialize the field by typing `pipenv run invenio rdm-records custom-fields init`. Restart your instance, and you should see the fields appear in the deposit form. If you create a record, the metadata will also appear in the UI. By default, much of the optional field metadata will appear in both the "Additional details" section and in a condensed citation style form in the "Details" sidebar of the landing pages. This is a bit repetitive, and you can remove the metadata from the "Additional details" section with the configuration.
+You'll need to initialize the field by typing `invenio rdm-records custom-fields init` (preceded by `uv run` or `pipenv run` as appropriate). Restart your instance, and you should see the fields appear in the deposit form. If you create a record, the metadata will also appear in the UI. By default, much of the optional field metadata will appear in both the "Additional details" section and in a condensed citation style form in the "Details" sidebar of the landing pages. This is a bit repetitive, and you can remove the metadata from the "Additional details" section with the configuration.
 
 ```python
 MEETING_CUSTOM_FIELDS_UI["hide_from_landing_page"] = True
@@ -107,7 +107,7 @@ RDM_CUSTOM_FIELDS_UI = [
 ]
 ```
 
-You'll need to initialize the field by typing `pipenv run invenio rdm-records custom-fields init`. Restart your instance, and you should see the fields appear in the deposit form.
+You'll need to initialize the field by typing `invenio rdm-records custom-fields init` (preceded by `uv run` or `pipenv run` as appropriate). Restart your instance, and you should see the fields appear in the deposit form.
 
 You can activate both the meeting and publishing fields at once, with this full configuration:
 
@@ -168,7 +168,7 @@ RDM_CUSTOM_FIELDS_UI = [
 MEETING_CUSTOM_FIELDS_UI["hide_from_landing_page"] = True
 ```
 
-You'll need to initialize the field by typing `pipenv run invenio rdm-records custom-fields init`. Restart your instance, and you should see the fields appear in the deposit form like:
+You'll need to initialize the field by typing `invenio rdm-records custom-fields init` (preceded by `uv run` or `pipenv run` as appropriate). Restart your instance, and you should see the fields appear in the deposit form like:
 
 ![Optional field result (deposit form)](./imgs/pub_info_deposit_form.png)
 

--- a/docs/operate/customize/record_deletion.md
+++ b/docs/operate/customize/record_deletion.md
@@ -1,6 +1,6 @@
 # Record deletion
 
-_Introduced in vNext_
+_Introduced in v14_
 
 Records could always be deleted through the admin panel, but this feature allows records to be deleted by users themselves. Specifically, you can choose whether and under which criteria that records can be immediately deleted and user's ability to request deletion.
 
@@ -39,7 +39,7 @@ Perhaps you:
 * Have an internal process which you would prefer users use rather than deleting records. For example, replacing the file for a user via email instead of deleting the record.
 * Have introduced a new feature that the user might not be familiar with. For example, DOIs are now optional in your instance and can be changed by editing the record.
 
-For all these cases, you can redirect the user by defining a checklist which will present the correct behaviour to the user. 
+For all these cases, you can redirect the user by defining a checklist which will present the correct behaviour to the user.
 
 ```python
 RDM_IMMEDIATE_RECORD_DELETION_CHECKLIST = [

--- a/docs/operate/customize/static_pages.md
+++ b/docs/operate/customize/static_pages.md
@@ -67,16 +67,16 @@ To load the new static page to your instance, you have 2 options:
 
 1. Run the instance setup command `invenio-cli services setup`: the command will find the pages defined as above and load them. **Warning: this command will delete all your data!**
 
-2. In a previously created instance folder, run:
+2. In a previously created instance folder, run (preceded by `uv run` or `pipenv run` as appropriate):
 
 ```bash
-pipenv run invenio rdm pages create
+invenio rdm pages create
 ```
 
 For updating existing templates:
 
 ```bash
-pipenv run invenio rdm pages create --force
+invenio rdm pages create --force
 ```
 
 This will wipe out all previously created static pages and load them again. In other words, it will delete the templates you have removed from your `pages.yaml` and update the existing templates with the changes you have made, if any.
@@ -101,10 +101,10 @@ templates
 └── my_site/my_custom_base_template.html
 ```
 
-After making this change, you will have to restart your instance and run
+After making this change, you will have to restart your instance and run (preceded by `uv run` or `pipenv run` as appropriate)
 
 ```bash
-pipenv run invenio rdm pages create --force
+invenio rdm pages create --force
 ```
 
 ## Edit pages
@@ -159,10 +159,10 @@ templates
 └── my_site/my_custom_base_template.html
 ```
 
-After making this change, you'll have to restart your instance and run
+After making this change, you'll have to restart your instance and run (preceded by `uv run` or `pipenv run` as appropriate)
 
 ```bash
-pipenv run invenio rdm pages create --force
+invenio rdm pages create --force
 ```
 
 ## Static Pages Content HTML Sanitization
@@ -201,8 +201,8 @@ PAGES_ALLOWED_EXTRA_HTML_ATTRS = {
 
 ```
 
-After adding these configs, you'll have to restart your instance and run
+After adding these configs, you'll have to restart your instance and run (preceded by `uv run` or `pipenv run` as appropriate)
 
 ```bash
-pipenv run invenio rdm pages create --force
+invenio rdm pages create --force
 ```

--- a/docs/operate/customize/users.md
+++ b/docs/operate/customize/users.md
@@ -59,7 +59,7 @@ but is empty, no default user is created.
 
 ## Change password
 
-To set or change the password for an existing user, create a new shell with `pipenv run invenio shell` and run:
+To set or change the password for an existing user, create a new shell with `invenio shell` (preceded by `uv run` or `pipenv run` as appropriate) and run:
 
 ```python
 from flask_security.utils import hash_password
@@ -79,7 +79,8 @@ You might need to add users or modify their permissions after the initial user v
 Use the invenio users create command. The `--active` flag ensures the user can log in immediately, and `--confirm` confirms their email address (assuming email verification is enabled by default).
 
 ```shell
-pipenv run invenio users create email@domain.edu --password <password> --active --confirm
+# precede by `uv run` or `pipenv run` as appropriate
+invenio users create email@domain.edu --password <password> --active --confirm
 ```
 
 This will automatically confirm the account. If you prefer the user to verify their email address themselves, omit the `--confirm` parameter:
@@ -127,7 +128,7 @@ invenio access allow superuser-access user <e-mail>
 
 Only confirmed accounts can log in to InvenioRDM. You can confirm an account automatically upon creation using the `--confirm` parameter.
 
-Alternatively you can confirm an account programmatically by opening a new shell using `pipenv run invenio shell` and
+Alternatively you can confirm an account programmatically by opening a new shell using `invenio shell` (preceded by `uv run` or `pipenv run` as appropriate) and
 running:
 
 ```python

--- a/docs/operate/customize/vocabularies/funding.md
+++ b/docs/operate/customize/vocabularies/funding.md
@@ -41,7 +41,7 @@ Here is an example of two such records in YAML format:
 
 The **Funder** vocabulary uses the new DataStreams API for importing entries. You can find more information about this new API in [RFC 0053](https://github.com/inveniosoftware/rfcs/pull/53).
 
-** Version 13 and later **
+**Version 13 and later**
 
 You can set up a job to import the ROR funders dataset directly by going
 to https://my-repository-url/administration/jobs
@@ -56,13 +56,13 @@ be loaded.
 You can also use the "Schedule job" button to download the latest version of
 the ROR vocabulary on a regular schedule.
 
-If you prefer to work on the command line, you can type
+If you prefer to work on the command line, you can type (preceded by `pipenv run` or `uv run` as appropriate)
 
 ```bash
-pipenv run invenio vocabularies update --vocabulary funders --origin ror-http
+invenio vocabularies update --vocabulary funders --origin ror-http
 ```
 
-** Version 12 and earlier **
+**Version 12 and earlier**
 
 You can fetch the [ROR data dump](https://ror.readme.io/docs/data-dump) and import it directly using the following command:
 

--- a/docs/operate/customize/vocabularies/index.md
+++ b/docs/operate/customize/vocabularies/index.md
@@ -10,7 +10,7 @@ Because fixtures are loaded when `invenio-cli services setup` is run, you will w
 
 Behind the scenes, fixtures are currently loaded in a 2-step process: first `invenio-cli services setup` puts them in the task queue to be loaded and second the task workers take up those tasks and actually create the fixture entries in the database and document index. This is why you won't see changes until you run `invenio-cli run` initially.
 
-Another behind the scenes note, `invenio-cli services setup` calls `pipenv run invenio rdm-records fixtures` to deal with fixtures. That command-line tool (part of the internal API and therefore subject to change) assesses if fixtures are already existing before submitting them to the task queue. This means, it can be used to **add** new fixtures to your instance by being run again later which can be useful to add new subjects. It won't override/update previously existing fixtures.
+Another behind the scenes note, `invenio-cli services setup` calls `invenio rdm-records fixtures` to deal with fixtures. That command-line tool (part of the internal API and therefore subject to change) assesses if fixtures are already existing before submitting them to the task queue. This means, it can be used to **add** new fixtures to your instance by being run again later which can be useful to add new subjects. It won't override/update previously existing fixtures.
 
 !!! warning "Unsupported cases"
     There is no moment between database creation and fixture loading when you can create database entries (e.g., a role) and then use them for your fixtures. However, you can still create roles and assign them to users manually with `invenio` commands.
@@ -19,20 +19,19 @@ Another behind the scenes note, `invenio-cli services setup` calls `pipenv run i
 
 _Introduced in v12_
 
-To add or update a vocabulary fixture:
+To add or update a vocabulary fixture (precede with `uv` or `pipenv` as appropriate):
 
 ```bash
-pipenv run invenio rdm-records add-to-fixture <vocabulary_name>
+invenio rdm-records add-to-fixture <vocabulary_name>
 ```
 
 This command enables the addition or updating of entries within specified vocabulary fixtures in InvenioRDM and is operational on live instances.
 Note that its functionality is restricted to the addition of new vocabularies or the updating of existing ones.
 
-Example
-To update the 'contributorsroles' vocabulary fixture, use:
+For example, to update the 'contributorsroles' vocabulary fixture, use:
 
 ```bash
-pipenv run invenio rdm-records add-to-fixture contributorsroles
+invenio rdm-records add-to-fixture contributorsroles
 ```
 
 !!! warning "Note"

--- a/docs/operate/customize/vocabularies/names.md
+++ b/docs/operate/customize/vocabularies/names.md
@@ -133,14 +133,24 @@ First, you should store the credentials to access the ORCID Public Data Sync in 
 
 #### Installing
 
-Then, you should install the required `s3fs` dependency. This can be achieved by adding the following to the `Pipfile` in your instance:
+Then, you should install the required `s3fs` dependency. This can be achieved by adding the following to your project file:
 
-```toml
-[packages]
-...
-invenio-vocabularies = {extras = ["s3fs"]}
-...
-```
+=== "pyproject.toml"
+
+  ```toml
+  [project]
+
+  dependencies = [
+    "invenio-vocabularies[s3fs]",
+  ]
+  ```
+
+=== "Pipfile"
+
+  ```ini
+  [packages]
+  invenio-vocabularies = {extras = ["s3fs"]}
+  ```
 
 #### Configuring
 

--- a/docs/operate/customize/vocabularies/subjects.md
+++ b/docs/operate/customize/vocabularies/subjects.md
@@ -33,16 +33,26 @@ package. This package is provided by Northwestern University, and we hope that m
 
 In order to install that extension:
 
-```
-cd /path/to/your/instance
-pipenv install invenio-subjects-mesh
-```
+=== "uv"
 
-You should see the dependency being added to the `Pipfile`.
+    ```shell
+    cd /path/to/your/instance
+    uv add invenio-subjects-mesh
+    ```
+
+=== "pipenv"
+
+    ```shell
+    cd /path/to/your/instance
+    pipenv install invenio-subjects-mesh
+    ```
+
+You should see the dependency being added to your project file (`pyproject.toml` for `uv`, `Pipfile` for `pipenv`).
 
 Then you need to run the fixtures command and start your instance (if not running already).
 
 ```
+# precede this command by uv run or pipenv run as appropriate
 invenio rdm-records fixtures
 invenio-cli run
 ```

--- a/docs/operate/ops/logging.md
+++ b/docs/operate/ops/logging.md
@@ -104,11 +104,24 @@ You can configure Celery, SQLAlchemy, and Redis to send logs to Sentry. This beh
 
 To enable Sentry integration, follow these steps:
 
-- Install the Sentry SDK: In your `Pipfile`, under the `[packages]` section, add the `invenio-logging` package with the `sentry` extra:
+- Install the Sentry SDK:
 
-```python
-invenio-logging = {extras = ["sentry"]}
-```
+=== "pyproject.toml"
+
+  ```toml
+  [project]
+
+  dependencies = [
+    "invenio-logging[sentry]",
+  ]
+  ```
+
+=== "Pipfile"
+
+  ```ini
+  [packages]
+  invenio-logging = {extras = ["sentry"]}
+  ```
 
 - Configure Logging Backends: In your `invenio.cfg` file, add the desired logging backends and configure the Sentry initialization options:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,4 @@
-# Invenio-cli commands reference 
+# Invenio-cli commands reference
 
 **Summary**
 
@@ -340,8 +340,8 @@ The primary intended purpose of this command is for developers to install a deve
 
 Lock Python dependencies.
 
-This creates a `Pipfile.lock` in your instance with hashes and versions of all
-Python packages. This ensures you have reproducible builds, and that you don't risk
+This creates a lock file depending on your python package manager: `uv.lock` if using `uv` and `Pipfile.lock` if using `pipenv`.
+It contains hashes and versions of all Python packages. This ensures you have reproducible builds, and that you don't risk
 having new patch-level versions of third-party Python packages break your build.
 
 **Options**

--- a/docs/reference/virtualenvs.md
+++ b/docs/reference/virtualenvs.md
@@ -72,7 +72,7 @@ This means that a virtual environment has its own ``python`` and ``pip`` command
 
 - ``pyenv`` is a tool to manage and install multiple Python **distributions**.
 - ``venv`` and ``virtualenv`` are tools to create **virtual environments** for a specific installation of a **distribution**.
-- ``pipenv``, ``poetry``, ``virtualenv-wrapper`` are tools used to manage ``venv`` and/or ``virtualenv``.
+- ``uv``, ``pipenv``, ``poetry``, ``virtualenv-wrapper`` are tools used to manage ``venv`` and/or ``virtualenv``.
 - ``brew``, ``yum``, ``apt`` are package manages that can be used to install e.g. multiple Python **distributions**.
-- ``invenio-cli`` uses ``pipenv`` on your local machine or in containers to create and manage
+- ``invenio-cli`` uses ``uv`` (or ``pipenv`` in legacy installations) on your local machine or in containers to create and manage
   a **virtual environment**.

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -16,28 +16,6 @@ The throughline of this article is a sequential series of steps to execute. **Do
 
     Always backup your database, statistics indices and files before you try to perform an upgrade.
 
-## Check your database for the `alembic_version` table
-
-InvenioRDM v13 contained a race condition that, in some cases, prevented the `alembic_version` table from being created in the database. [Alembic](https://alembic.sqlalchemy.org/) uses this table to track database schema migrations, and you cannot upgrade to v14 without it.
-
-To check whether your database has the `alembic_version` table, log in to the database and run the following SQL query:
-
-```sql
-SELECT * FROM alembic_version;
-```
-
-If you get `ERROR: relation "alembic_version" does not exist`, the table is missing and you must create it before proceeding.
-
-To create the table, you need to run the command on the InvenioRDM server. The server **must** be using the same source code version as the one used to install the current database schema. In other words, if you upgraded the source code to a newer v13 release after installation, the source code and database schema may be out of sync and you **cannot** safely use the command below. If that is your situation, please ask for help on our Discord server.
-
-On the server, run the following command to create the `alembic_version` table:
-
-```bash
-pipenv run invenio alembic stamp
-```
-
-Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
-
 ## Switch from pipenv to uv — optional but recommended
 
 Although not strictly necessary for this upgrade, we highly encourage you to switch to [uv](https://docs.astral.sh/uv/) from [pipenv](https://pipenv.pypa.io/) for your Python package and project manager, for improvements in speed, ergonomics, and [security](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns). Future releases will only document steps using `uv` commands and may remove support for `pipenv`.
@@ -114,8 +92,6 @@ With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends us
     FROM ghcr.io/...
     ```
 
-TODO: adapt text to reflect Python 3.14 being recommended or a requirement based on July discussion
-
 ## Switch from npm to pnpm — optional but recommended
 
 [Pnpm](https://pnpm.io/) is now the recommended tool to manage Javascript dependencies in InvenioRDM (don't worry npm still works) because it is much faster, [has better protection against supply chain attacks](https://pnpm.io/supply-chain-security), and has good community support. If you have it installed, `invenio-cli` and lower level `invenio` commands will use it under the hood.
@@ -172,7 +148,7 @@ Here are the core sequential steps to upgrade to InvenioRDM v14.
 ### Upgrade invenio-cli
 
 Make sure you have the latest `invenio-cli` installed. For InvenioRDM v14,
-it should be v1.12.0+. (TODO: release v1.12)
+it should be v1.12.0.
 
 ```bash
 $ invenio-cli --version
@@ -180,22 +156,7 @@ invenio-cli, version 1.12.0
 ```
 
 ### Upgrade packages
-#### Upgrade option 1: In-place
-
-This approach upgrades the dependencies in place. At the end of the process,
-your virtual environment for the v13 version will be completely replaced
-with the v14 environment and dependencies.
-
-```bash
-cd <my-site>
-
-# Upgrade to InvenioRDM vNext
-invenio-cli packages update v14
-# Re-build assets
-invenio-cli assets build
-```
-
-#### Upgrade option 2: New virtual environment
+#### Step 1: New virtual environment
 
 This approach will create a new virtual environment and leaves the v13 one as-is.
 If you are using a docker image on your production instance this will be the
@@ -208,13 +169,19 @@ option you choose.
     make sure you copy them over to the new `venv` folder in the same location.
     The command `invenio files location list` shows the file upload location.
 
-##### Step 1
-
 - create a new virtual environment
 - activate your new virtual environment
-- install `invenio-cli` by running `pip install invenio-cli`
+- install `invenio-cli` by running
 
-##### Step 2
+```bash
+# if using uv
+uv pip install invenio-cli
+
+# if using pipenv
+pip install invenio-cli
+```
+
+#### Step 2
 
 Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` or `<my-site>/Pipfile`:
 
@@ -235,15 +202,7 @@ Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` or
     ```
 
 
-##### Step 3
-
-Update the lock file (whether `uv` or `pipenv`):
-
-```bash
-invenio-cli packages lock
-```
-
-##### Step 4
+#### Step 4
 
 Install InvenioRDM v14:
 
@@ -251,25 +210,41 @@ Install InvenioRDM v14:
 invenio-cli install
 ```
 
-#### Activate the virtual environment
-
-Before running any `invenio` commands, activate your virtual environment shell:
-
-```bash
-$ invenio-cli shell
-Launching subshell in virtual environment...
-source <path to virtualenvs>/bin/activate
-```
-
-This step ensures that all subsequent commands use the correct Python environment and installed dependencies.
-
-!!! note
-    If you are upgrading in an environment that does not use a Python virtualenv, you can skip this step.
-
 
 ### Apply database migrations
 
-The database migration consists of two steps: a pre-migration step that cleans up the existing database schema, followed by an Alembic upgrade to the v14 schema.
+The database migration consists of three steps:
+
+- check about existing `alembic_version` table
+- pre-migration step that cleans up the existing database schema
+- Alembic upgrade to the v14 schema
+
+#### Check your database for the `alembic_version` table
+
+InvenioRDM v13 contained a race condition that, in some cases, prevented the `alembic_version` table from being created in the database. [Alembic](https://alembic.sqlalchemy.org/) uses this table to track database schema migrations, and you cannot upgrade to v14 without it.
+
+To check whether your database has the `alembic_version` table, log in to the database and run the following SQL query:
+
+```sql
+SELECT * FROM alembic_version;
+```
+
+If you get `ERROR: relation "alembic_version" does not exist`, the table is missing and you must create it before proceeding.
+
+To create the table, you need to run the command on the InvenioRDM server. The server **must** be using the same source code version as the one used to install the current database schema. In other words, if you upgraded the source code to a newer v13 release after installation, the source code and database schema may be out of sync and you **cannot** safely use the command below. If that is your situation, please ask for help on our Discord server.
+
+On the server, run the following command to create the `alembic_version` table:
+
+```bash
+# if using uv
+uv run invenio alembic stamp
+
+# if using pipenv
+pipenv run invenio alembic stamp
+```
+
+Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
+
 
 #### Run the pre-migration step
 
@@ -320,21 +295,10 @@ Execute the data migration script to update the content of the DB:
     invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name migrate_13_0_to_14_0.py)
     ```
 
-#### OAuth client changes
-
-The `extra_data` column of the `oauthclient_remoteaccount` table, storing remote-specific user information as required by various integrations, has been migrated from the `JSON` type to the `JSONB` type (only on PostgreSQL databases).
-This gives significant performance improvements when running certain queries.
-An automated Alembic migration is included and has been executed when you ran the [database migration](#apply-database-migrations) step above.
-
-However, if your `oauthclient_remoteaccount` table has more than ~50k rows and you are unable to take the system offline for an update, this operation could overload your database and create a lock lasting several minutes, due to the need to individually transform every row.
-To avoid issues in such cases, we recommend instead running the migration manually.
-Please follow [the upgrade guide](https://invenio-oauthclient.readthedocs.io/en/latest/upgrading.html#v6-0-0).
-
 ### Update search engine mappings and content
 
 Many mappings have been updated in this release. You can perform granular changes if you want to avoid downtimes or simply discard and rebuild the indices in one go.
 
-TODO: Check if it is indeed the case that the discard and rebuild is enough
 
 **Discard and rebuild indices**
 
@@ -348,23 +312,6 @@ invenio rdm-records custom-fields init
 invenio communities custom-fields init
 invenio rdm rebuild-all-indices
 ```
-
-OR
-
-**Granular changes**
-
-Apply these granular changes:
-
-- `invenio index update --no-check rdmrecords-records-record-v7.0.0` (for record deletion feature)
-- `invenio index update --no-check rdmrecords-drafts-draft-v6.0.0` (for record deletion feature)
-- Update OAI-PMH percolators index for records by using the [recipe below](#oai-pmh-percolator-mapping-update) (for record deletion feature)
-- `invenio index update --no-check requests-request-v1.0.0` (for commenting, curation, and record deletion)
-- Update the job logs index template by using the [recipe below](#job-logs-index-template-update) (for job logs changes)
-- `invenio index update --no-check requestevents-requestevent-v1.0.0` (for commenting)
-- Update all comment request events in the live index by running the [recipe below](#comment-events-update)
-- `invenio index update communitymembers-members-member-v1.0.0 --no-check` (for request to join community)
-- `invenio index update communitymembers-archivedinvitations-archivedinvitation-v1.0.0 --no-check` (for request to join community)
-- `invenio rdm-records rebuild-all-indices --order requests` (for request commenting)
 
 #### OAI-PMH percolator mapping update
 
@@ -399,7 +346,6 @@ current_search_client.indices.put_mapping(
 # Reindex all percolator queries from OAISets
 oaipmh_service = current_rdm_records.oaipmh_server_service
 oaipmh_service.rebuild_index(identity=system_identity)
-```
 
 #### Job Logs Index Template Update
 
@@ -408,45 +354,10 @@ The job logs datastream index template has been updated to explicitly map two ne
 - `task_id` — unique identifier for the Celery task that produced the log
 - `parent_task_id` — identifier of the parent task (null for root tasks, set for subtasks)
 
-Because the datastream index has `"dynamic": true` on the `context` object, existing indexed logs are unaffected. However, to ensure the new fields are properly mapped in future write indices, you need to:
+Because the datastream index has `"dynamic": true` on the `context` object, existing indexed logs are unaffected.
 
 1. **Update the index template** — add the two new fields under `mappings.properties.context.properties` of the `<PREFIX>-job-logs-v1.0.0` template.
-
-    Via the OpenSearch Dashboards UI: navigate to **Index Management → Templates**, find the template and edit it.
-
-    Or via curl:
-
-    ```bash
-    curl -X POST "http://<OPENSEARCH_HOST>/_index_template/<PREFIX>-job-logs-v1.0.0" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "index_patterns": ["<PREFIX>-job-logs*"],
-        "data_stream": {},
-        "template": {
-          "mappings": {
-            "properties": {
-              "@timestamp": { "type": "date" },
-              "level": { "type": "keyword" },
-              "message": { "type": "text" },
-              "module": { "type": "keyword" },
-              "function": { "type": "keyword" },
-              "line": { "type": "integer" },
-              "context": {
-                "type": "object",
-                "properties": {
-                  "job_id": { "type": "keyword" },
-                  "run_id": { "type": "keyword" },
-                  "identity_id": { "type": "keyword" },
-                  "task_id": { "type": "keyword" },
-                  "parent_task_id": { "type": "keyword" }
-                },
-                "dynamic": true
-              }
-            }
-          }
-        }
-      }'
-    ```
+   Done with the `invenio index init`
 
 2. **Trigger a rollover of the datastream** — this creates a new backing index using the updated template, cleanly separating old and new log documents.
 
@@ -458,150 +369,6 @@ Because the datastream index has `"dynamic": true` on the `context` object, exis
     curl -X POST "http://<OPENSEARCH_HOST>/<PREFIX>-job-logs/_rollover"
     ```
 
-!!! note
-    The template update is done in the **Index Templates** section and the rollover in the **Data Streams** section of the OpenSearch Dashboards UI.
-
-#### Comment events update
-
-You will need to run the code below against the live index **before the new code is deployed**. The script is updating all requestevents documents of type comment to mark them as "parent". This is required so that the `join` relationship queries succeed (the request timeline will be broken otherwise!!!). The script exits when all comments are updated. After deployment of the new code you might need to rerun it to fix the delta-comments created between the last run of the script and the deployment of the new code.
-
-TODO: this should be a script
-
-```python
-import time
-from datetime import datetime
-
-import click
-from invenio_search import current_search_client
-from invenio_search.api import build_alias_name
-from invenio_requests.records.api import RequestEvent
-
-
-click.secho("Starting parent_child field migration for parent comments...", fg="green")
-
-# Poll interval in seconds to recheck remaining comments without tagged as parents
-poll_interval = 10
-
-# Get the OpenSearch client and index name
-index_name = build_alias_name(RequestEvent.index._name)
-
-click.echo(f"Target index: {index_name}")
-
-# Capture migration start timestamp
-migration_start_time = datetime.utcnow().isoformat()
-click.echo(f"Migration timestamp: {migration_start_time}")
-
-# Query for documents that need updating (created before migration, without parent_child field)
-def get_pending_count():
-    """Get count of documents that still need updating."""
-    return current_search_client.count(
-        index=index_name,
-        body={
-            "query": {
-                "bool": {
-                    "must": [
-                        # Created before migration started
-                        {"range": {"created": {"lt": migration_start_time}}},
-                    ],
-                    "must_not": [
-                        # Has parent_id (is a child)
-                        {"exists": {"field": "parent_id"}},
-                        # Already has parent_child field
-                        {"exists": {"field": "parent_child"}},
-                    ],
-                }
-            }
-        },
-    )
-
-# Initial count
-initial_count_response = get_pending_count()
-initial_count = initial_count_response["count"]
-
-click.echo(f"\nFound {initial_count} parent comments to update")
-
-# Trigger the update (async with wait_for_completion=False)
-click.echo("\nTriggering update_by_query...")
-update_response = current_search_client.update_by_query(
-    index=index_name,
-    body={
-        "query": {
-            "bool": {
-                "must": [
-                    # Created before migration started
-                    {"range": {"created": {"lt": migration_start_time}}},
-                ],
-                "must_not": [
-                    # Has parent_id (is a child)
-                    {"exists": {"field": "parent_id"}},
-                    # Already has parent_child field
-                    {"exists": {"field": "parent_child"}},
-                ],
-            }
-        },
-        "script": {
-            "source": "ctx._source.parent_child = ['name': 'parent']",
-            "lang": "painless",
-        },
-    },
-    wait_for_completion=False,
-    refresh=True,
-)
-
-task_id = update_response.get("task")
-if task_id:
-    click.echo(f"Task ID: {task_id}")
-
-click.echo(f"\nPolling cluster every {poll_interval}s until completion...")
-click.echo("(Checking for documents created before {})".format(migration_start_time))
-
-# Poll until all documents are updated
-total_updated = 0
-poll_count = 0
-
-with click.progressbar(
-    length=initial_count,
-    label="Migrating parent comments",
-    show_eta=True,
-) as bar:
-    bar.update(0)
-
-    while True and initial_count != 0:
-        poll_count += 1
-        time.sleep(poll_interval)
-
-        # Check how many documents still need updating
-        pending_response = get_pending_count()
-        pending_count = pending_response["count"]
-
-        # Calculate how many have been updated
-        updated_since_last = (initial_count - total_updated) - pending_count
-        if updated_since_last > 0:
-            bar.update(updated_since_last)
-            total_updated += updated_since_last
-
-        # Check if we're done
-        if pending_count == 0:
-            # Make sure we update to 100%
-            remaining = initial_count - total_updated
-            if remaining > 0:
-                bar.update(remaining)
-            break
-
-        # Progress update every 10 polls
-        if poll_count % 10 == 0:
-            click.echo(f"\nStill processing... {pending_count} documents remaining")
-
-click.secho(f"\n✓ Migration complete!", fg="green")
-click.echo(f"Total updated: {initial_count} parent comments")
-
-# Final verification
-final_pending = get_pending_count()["count"]
-if final_pending == 0:
-    click.secho("✓ Verification passed: All documents updated", fg="green")
-else:
-    click.secho(f"⚠ Warning: {final_pending} documents still pending", fg="yellow")
-```
 
 ### Update vocabularies
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -16,11 +16,17 @@ The throughline of this article is a sequential series of steps to execute. **Do
 
     Always backup your database, statistics indices and files before you try to perform an upgrade.
 
-## Switch from pipenv to uv — optional but recommended
+## Switch from pipenv to uv
+
+*Required for upgrade*: No, but recommended. If switch not done, additional steps detailed below are needed.
+
+### Switching to uv
 
 Although not strictly necessary for this upgrade, we highly encourage you to switch to [uv](https://docs.astral.sh/uv/) from [pipenv](https://pipenv.pypa.io/) for your Python package and project manager, for improvements in speed, ergonomics, and [security](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns). Future releases will only document steps using `uv` commands and may remove support for `pipenv`.
 
 See the dedicated [Pipenv-to-uv migration guide](../uv-upgrade.md), which includes a helper script that converts your `Pipfile` to `pyproject.toml`, updates the `site/` package, and adjusts `.invenio` (`python_package_manager = uv`).
+
+### Not switching to uv
 
 If you want to keep using pipenv for now AND you want to use the recommended base Docker image for InvenioRDM v14 in your Dockerfile, you will need to edit your Dockerfile to install `pipenv` (it is not installed in the base image anymore):
 
@@ -32,9 +38,13 @@ RUN pip install pipenv
 # keep the rest of your Dockerfile as it was with calls to pipenv
 ```
 
-## Switch to supported Python version — required if not already done
+## Switch to supported Python version
 
-With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends using Python 3.14 for its performance improvements and future-facing features. Python versions still supported by the Python community but below 3.14 (3.10, 3.11, 3.12, 3.13) *may* work but with varying levels of certainty. With high confidence Python 3.11 will work for instance. On the other hand, Python 3.10 has never been recommended and always faced issues, so it will likely not work. Details below take Python 3.14 as the example version to upgrade to.
+*Required for upgrade*: Yes from Python 3.9 to 3.11+, with Python 3.14 being the the recommended and best supported version. If already running 3.11+ this is not needed for the upgrade to InvenioRDM v14.
+
+With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends using Python 3.14 for its performance improvements and future-facing features. Python versions still supported by the Python community but below 3.14 (3.10, 3.11, 3.12, 3.13) *may* work but with varying levels of certainty. With high confidence Python 3.11 will work for instance. On the other hand, Python 3.10 has never been recommended and always faced issues, so it will likely not work.
+
+The steps below take Python 3.14 as the example version to upgrade to.
 
 1.  Install Python 3.14 so it can be used by your application (including in new [virtualenv](../../reference/virtualenvs.md) created by invenio-cli). We only list two methods here — the internet is rife with other examples.
 
@@ -69,30 +79,17 @@ With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends us
         python_version = "3.14"
         ```
 
-3.  Regenerate the lock file
-
-    === "uv"
-
-        ```bash
-        uv lock --refresh
-        ```
-
-    === "pipenv"
-
-        ```bash
-        pipenv lock
-        ```
-
-    You will then want to use a new virtualenv like [detailed below](#upgrade-option-2-new-virtual-environment). At this point you may want to re-install the v13 packages in this new environment just to make sure your instance is compatible with Python 3.14 and resolve any issues specific to that if any. Keep in mind that InvenioRDM v14 may resolve some too.
-
-4.  Change the `FROM` line in your Dockerfile to a base image using Python 3.14
+3.  Change the `FROM` line in your Dockerfile to a base image using Python 3.14
 
     ```Dockerfile
-    # TODO: Fill with appropriate source
-    FROM ghcr.io/...
+    FROM <Invenio base image with OS of your choice supporting v14 and running Python 3.14>
     ```
 
-## Switch from npm to pnpm — optional but recommended
+## Switch from npm to pnpm
+
+*Required for upgrade*: No, but recommended. If you want to keep using npm, settings to verify are detailed below.
+
+### Switching to pnpm
 
 [Pnpm](https://pnpm.io/) is now the recommended tool to manage Javascript dependencies in InvenioRDM (don't worry npm still works) because it is much faster, [has better protection against supply chain attacks](https://pnpm.io/supply-chain-security), and has good community support. If you have it installed, `invenio-cli` and lower level `invenio` commands will use it under the hood.
 
@@ -120,24 +117,58 @@ With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends us
 
 That's it, faster JavaScript package resolutions are yours now!
 
-**You can now also optionally lock your js dependencies!**
+### Not switching to pnpm
 
-Generate the lockfile with `invenio-cli assets lock` and commit the resulting `pnpm-lock.yaml` and `package.json` at the project root. Re-run `assets lock` whenever your JavaScript dependencies change.
+You can keep using npm to manage JS dependencies. To do so, verify that the following are set:
 
-!!! info "Building production Docker images with pnpm"
+1.  "npm" is set as your invenio javascript package manager in `.invenio`.
 
-    - Ensure the image has Node.js ≥18.12 and `pnpm` installed (the `inveniosoftware/almalinux:1` base image ships Node 16, so switch its `nodejs` module stream to `22` and install `pnpm` via `npm install -g pnpm@<version>`).
-    - For best layer-cache reuse, run `pnpm install --frozen-lockfile --shamefully-hoist` in its own layer, fed only by `package.json` + `pnpm-lock.yaml`, placed above any layer that copies frequently-changing source.
+    ```ini
+    [cli]
+    javascript_package_manager = npm
+    ```
 
-## Switch from webpack to Rspack — optional but recommended
+2.  In your `invenio.cfg`, set:
 
-Switch from `webpack` to [Rspack](https://www.rspack.dev/) for asset bundling. Its Rust-based builds are much faster and drop-in compatible with the existing Invenio asset pipeline. In your `invenio.cfg`:
+    ```python
+    # The default is "pynpm:NPMPackage" but may change in a future major version
+    WEBPACKEXT_NPM_PKG_CLS = "pynpm:NPMPackage"
+    ```
+
+### Optionally lock your JS dependencies
+
+With either, pnpm or npm, you can now optionally lock your Javascript dependencies.
+Like the lock file used to freeze Python dependencies to a deterministic set, the
+generated lock file will let you deterministically set your Javascript dependencies.
+Finally, reproducible Javascript builds!
+
+Generate the lockfile with `invenio-cli assets lock` and commit at the project root the resulting:
+
+- `pnpm-lock.yaml` and `package.json` if using pnpm
+- `package-lock.json` and `package.json` if using npm
+
+Re-run `assets lock` whenever your JavaScript dependencies change.
+
+!!! info "Building production Docker images"
+
+    - Ensure the image has Node.js ≥18.12 and `pnpm` installed if using a custom image and pnpm (the `inveniosoftware/almalinux:1` base image ships Node 16, so switch its `nodejs` module stream to `22` and install `pnpm` via `npm install -g pnpm@<version>`).
+    - For best layer-cache reuse, have in its own layer, fed only by `package.json` + `pnpm-lock.yaml`/`package-lock.json`, placed above any layer that copies frequently-changing source.
+        * for pnpm: `RUN pnpm install --frozen-lockfile --shamefully-hoist`
+        * for npm: `RUN npm ci`
+
+## Switch from webpack to Rspack
+
+*Required for upgrade*: No, but recommended. Can be skipped without performing any change if not switching.
+
+We recommend switching from `webpack` to [Rspack](https://www.rspack.dev/) for asset bundling. Its Rust-based builds are much faster and drop-in compatible with the existing Invenio asset pipeline. In your `invenio.cfg`:
 
 ```python
 WEBPACKEXT_PROJECT = "invenio_assets.webpack:rspack_project"
 ```
 
-## Upgrade to InvenioRDM v14 proper — required
+## Upgrade to InvenioRDM v14 proper
+
+*Required for upgrade*: Yes! This *is* the main upgrade section afterall.
 
 Here are the core sequential steps to upgrade to InvenioRDM v14.
 
@@ -148,7 +179,7 @@ Here are the core sequential steps to upgrade to InvenioRDM v14.
 ### Upgrade invenio-cli
 
 Make sure you have the latest `invenio-cli` installed. For InvenioRDM v14,
-it should be v1.12.0.
+it should be v1.12.0 or higher. See [Install the command line tool](../../install/cli.md) for how to install it.
 
 ```bash
 $ invenio-cli --version
@@ -156,34 +187,8 @@ invenio-cli, version 1.12.0
 ```
 
 ### Upgrade packages
-#### Step 1: New virtual environment
 
-This approach will create a new virtual environment and leaves the v13 one as-is.
-If you are using a docker image on your production instance this will be the
-option you choose.
-
-!!! warning "Risk of losing data"
-
-    Your virtual environment folder a.k.a., `venv` folder, may contain uploaded files. If you kept the default
-    location, it is in `<venv folder>/var/instance/data`. If you need to keep those files,
-    make sure you copy them over to the new `venv` folder in the same location.
-    The command `invenio files location list` shows the file upload location.
-
-- create a new virtual environment
-- activate your new virtual environment
-- install `invenio-cli` by running
-
-```bash
-# if using uv
-uv pip install invenio-cli
-
-# if using pipenv
-pip install invenio-cli
-```
-
-#### Step 2
-
-Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` or `<my-site>/Pipfile`:
+Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` if using `uv` or `<my-site>/Pipfile` if using `pipenv`:
 
 === "pyproject.toml"
 
@@ -201,14 +206,37 @@ Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` or
     +++invenio-app-rdm = {extras = [...], version = "~=14.0.0"}
     ```
 
-
-#### Step 4
-
 Install InvenioRDM v14:
 
 ```bash
 invenio-cli install
 ```
+
+!!! warning "A note on virtual environments and possible data loss*
+
+    In previous upgrade notes (e.g., from InvenioRDM v12 to v13),
+    creation of a new virtual environment was mentioned as an option
+    where to install the new InvenioRDM version. Doing so carries
+    the risk of losing the uploaded files that are stored by default
+    in `<venv folder>/var/instance/data`. However, in practice, creating
+    a new virtualenv for an upgrade is a relatively niche case.
+
+    Indeed, if you are using containers to run your application
+    (and we recommend you do in production), then a new isolated
+    environment is created for each Docker image, but your data is persisted
+    elsewhere anyway. In this case, you shouldn't have to worry about
+    virtualenv data loss.
+
+    And if you are running your application outside of
+    a container (typically in development), doing the upgrade in-place
+    within your existing virtualenv is also not subject to data loss.
+
+    Only if you do create a new virtualenv (e.g., to upgrade Python version)
+    outside of the above scenarios, should you copy the folder with uploaded
+    files over to the new `venv` folder in the same location.
+    The command `invenio files location list` shows the file upload location.
+
+    As such we don't mention this option anymore.
 
 
 ### Apply database migrations
@@ -235,27 +263,35 @@ To create the table, you need to run the command on the InvenioRDM server. The s
 
 On the server, run the following command to create the `alembic_version` table:
 
-```bash
-# if using uv
-uv run invenio alembic stamp
+=== "uv"
 
-# if using pipenv
-pipenv run invenio alembic stamp
-```
+    ```bash
+    uv run invenio alembic stamp
+    ```
+
+=== "pipenv"
+
+    ```bash
+    pipenv run invenio alembic stamp
+    ```
 
 Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
-
 
 #### Run the pre-migration step
 
 Run one of the following commands, depending on whether your installation uses `uv` or `pipenv`:
 
-```bash
-# if using uv
-invenio shell $(find $(dirname $(dirname $(uv python find)))/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
-# if using pipenv
-invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
-```
+=== "uv"
+
+    ```bash
+    invenio shell $(find $(dirname $(dirname $(uv python find)))/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
+    ```
+
+=== "pipenv"
+
+    ```bash
+    invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
+    ```
 
 If the script completes successfully, it should end with output similar to the following:
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -4,13 +4,14 @@
 
 This article details the low-level steps to follow to upgrade your InvenioRDM v13 instance to v14.0.
 
-Version 14 introduces a number of default tooling changes (`pipenv` -> `uv`, `npm` -> `pnpm`, ...) and recommends using Python 3.14. Previous tools and Python versions will still work with this release, but this is the last release where we document the upgrade process with the old and new tools. Future releases will only detail the upgrade steps using the new default tools. Don't worry, we point to documentation to upgrade those aspects too.
+Version 14 introduces a number of default tooling changes (`pipenv` -> `uv`, `npm` -> `pnpm`, ...) and recommends using Python 3.14. Previous tools and Python versions will still work with this release, but this is the last release where we document the upgrade process with the old and new tools. In particular, this is the last version where we document usage of `pipenv`. Future releases will only detail the upgrade steps using the new default tools or assuming them (most visibly only `uv`). Don't worry, we point to documentation below that you can follow at your pace (even after upgrade) to switch to those tools.
 
 As usual, these steps do assume an existing installation of InvenioRDM v13, the previous version.
-If your InvenioRDM installation is older than v13, you must first upgrade
-to v13 before proceeding with the steps in this guide. However, it doesn't assume you are necessarily on [v13.1](../v13/version-v13.1.0.md), and the instructions will work wether you are on v13.0.x or v13.1.y.
+If your InvenioRDM installation is older than v13, you must first upgrade to v13 before proceeding
+with the steps in this guide. However, it doesn't assume you are necessarily on
+[v13.1](../v13/version-v13.1.0.md). The instructions will work whether you are on v13.0.x or v13.1.y.
 
-The throughline of this article is a sequential series of steps to execute. **Do read** the optional sections as they indicate changes to apply even if NOT adopting change. We highly recommend running the steps in a local development environment first where experience from the particularities of your instance can be gained without data loss worry. Then we recommend you run the steps into a staging environment mirroring your production deployment and accrue further insight into specificities to your environment (or missing details in these update steps!). Equipped with that knowledge, running the steps on your production environment should be smooth.
+The throughline of this document is a sequential series of steps to execute. **Do read** the optional sections as they sometimes indicate changes to apply even if NOT adopting change. We highly recommend running the steps in a local development environment first where experience with the particularities of your instance can be gained without data loss worry. Then we recommend you run the steps into a staging environment mirroring your production deployment and accrue further insight into specificities of your environment (or missing details in these update steps!). Equipped with that knowledge, running the steps on your production environment should be smooth.
 
 !!! warning "Backup"
 
@@ -212,7 +213,7 @@ Install InvenioRDM v14:
 invenio-cli install
 ```
 
-!!! warning "A note on virtual environments and possible data loss*
+!!! warning "A note on virtual environments and possible data loss"
 
     In previous upgrade notes (e.g., from InvenioRDM v12 to v13),
     creation of a new virtual environment was mentioned as an option
@@ -382,6 +383,7 @@ current_search_client.indices.put_mapping(
 # Reindex all percolator queries from OAISets
 oaipmh_service = current_rdm_records.oaipmh_server_service
 oaipmh_service.rebuild_index(identity=system_identity)
+```
 
 #### Job Logs Index Template Update
 
@@ -425,13 +427,15 @@ For instance, you will want to run: `invenio rdm-records add-to-fixture detetype
 If you've customized any of these vocabularies for your instance, you will need to merge changes from the [source files in invenio-rdm-records](https://github.com/inveniosoftware/invenio-rdm-records/tree/master/invenio_rdm_records/fixtures/data/vocabularies) into the custom vocabulary files in your instance before running the `add-to-fixture` command.
 
 
-## Update your configuration or infrastructure — necessity depends on your instance
+## Update your configuration or infrastructure
 
-This last section highlights the changes to your configuration or infrastrcuture that you should assess. It's the last series of tweaks you want to assess and apply or not to your environment.
+*Required for upgrade*: Assess on a case by case basis. Typically optional.
+
+This last section highlights the changes to your configuration or infrastructure that you should assess. Determine if each applies to your instance, and perform the appropriate changes.
 
 ### invenio-cli run --host ... --port ...
 
-When running `invenio-cli run` with `--host`/`--port` passed on the command line or host/port defined in `.invenio.private`, it used to be that those values would override `SITE_UI_URL` and `SITE_API_URL`. This is no longer the case in order to allow for listening on a host/port (defined by passed host and port) different than the host/port used to generate the URLs. This is a common situation when listening on 0.0.0.0 and using the exact IP or fully qualified domain name for URL generation. As such you need to provide the appropriate `SITE_UI_URL` and `SITE_API_URL` values for your environment which typically means:
+When running `invenio-cli run` (in development) with `--host`/`--port` passed on the command line or host/port defined in `.invenio.private`, it used to be that those values would override `SITE_UI_URL` and `SITE_API_URL`. This is no longer the case in order to allow for listening on a host/port (defined by passed host and port) different than the host/port used to generate the URLs. This is a common situation when listening on 0.0.0.0, but using the fully qualified domain name for URL generation. As such, you need to provide the appropriate `SITE_UI_URL` and `SITE_API_URL` values for your environment which typically means:
 
 ```diff
 -SITE_UI_URL = "https://127.0.0.1"
@@ -440,6 +444,8 @@ When running `invenio-cli run` with `--host`/`--port` passed on the command line
 -SITE_API_URL = "https://127.0.0.1/api"
 +SITE_API_URL = "https://127.0.0.1:5000/api"
 ```
+
+in development outside containers.
 
 ### Overridable IDs in the deposit form
 
@@ -494,7 +500,9 @@ See also the [documentation on how to configure the new module](../../operate/cu
 
 That's it, you have upgraded to InvenioRDM v14!
 
-## Align "Thesis" and "Dissertation" resource types — optional
+## Align "Thesis" and "Dissertation" resource types
+
+*Required for upgrade*: No.
 
 Your upgrade is complete. This last section describes an **entirely optional** change that is not part of the upgrade. Nothing here affects your instance unless you choose to run it, and you can do so at any later time. Because resource types are a highly visible and commonly customized vocabulary, we suggest rather than impose this change. Decide together with your instance's stakeholders (librarians, curators) whether it fits your data before applying it.
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -86,21 +86,33 @@ TODO: adapt text to reflect Python 3.14 being recommended or a requirement based
 
 [Pnpm](https://pnpm.io/) is now the recommended tool to manage Javascript dependencies in InvenioRDM (don't worry npm still works) because it is much faster, [has better protection against supply chain attacks](https://pnpm.io/supply-chain-security), and has good community support. If you have it installed, `invenio-cli` and lower level `invenio` commands will use it under the hood.
 
-1. Locally, simply install [pnpm](https://pnpm.io/installation) version 10 (working version at time of writing).
+1.  Locally, simply install [pnpm](https://pnpm.io/installation) version 10 (working version at time of writing).
 
-2. Make sure to set "pnpm" as your invenio javascript package manager in `.invenio`.
+2.  Make sure to set "pnpm" as your invenio javascript package manager in `.invenio`.
 
-```ini
-[cli]
-# set this line or remove it altogether
-javascript_package_manager = pnpm
-```
+    ```ini
+    [cli]
+    # set this line or remove it altogether
+    javascript_package_manager = pnpm
+    ```
 
-You could remove the line altogether since pnpm is the new default if that line is not present.
+    You could remove the line altogether since pnpm is the new default if that line is not present.
 
-Generate the lockfile with `invenio-cli assets lock` and commit the resulting `pnpm-lock.yaml` and `package.json` at the project root. Re-run `assets lock` whenever your JavaScript dependencies change.
+3.  In your `invenio.cfg`, set:
+
+    ```python
+    WEBPACKEXT_NPM_PKG_CLS = "pynpm:PNPMPackage"
+    ```
+
+    to make sure pnpm is used by assets building commands inside and outside your containers.
+    The flag tells `flask-webpackext` which `pynpm` class to use when invoking the package manager,
+    so set it whenever you also enable pnpm.
 
 That's it, faster JavaScript package resolutions are yours now!
+
+**You can now also optionally lock your js dependencies!**
+
+Generate the lockfile with `invenio-cli assets lock` and commit the resulting `pnpm-lock.yaml` and `package.json` at the project root. Re-run `assets lock` whenever your JavaScript dependencies change.
 
 !!! info "Building production Docker images with pnpm"
 
@@ -113,10 +125,7 @@ Switch from `webpack` to [Rspack](https://www.rspack.dev/) for asset bundling. I
 
 ```python
 WEBPACKEXT_PROJECT = "invenio_assets.webpack:rspack_project"
-WEBPACKEXT_NPM_PKG_CLS = "pynpm:PNPMPackage"  # only when also using pnpm
 ```
-
-The second flag tells `flask-webpackext` which `pynpm` class to use when invoking the package manager, so set it whenever you also enable pnpm.
 
 ## Upgrade to InvenioRDM v14 proper — required
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -16,7 +16,29 @@ The throughline of this article is a sequential series of steps to execute. **Do
 
     Always backup your database, statistics indices and files before you try to perform an upgrade.
 
-## Switch from pipenv to uv — action needed even if optional but recommended
+## Check your database for the `alembic_version` table
+
+InvenioRDM v13 contained a race condition that, in some cases, prevented the `alembic_version` table from being created in the database. [Alembic](https://alembic.sqlalchemy.org/) uses this table to track database schema migrations, and you cannot upgrade to v14 without it.
+
+To check whether your database has the `alembic_version` table, log in to the database and run the following SQL query:
+
+```sql
+SELECT * FROM alembic_version;
+```
+
+If you get `ERROR: relation "alembic_version" does not exist`, the table is missing and you must create it before proceeding.
+
+To create the table, you need to run the command on the InvenioRDM server. The server **must** be using the same source code version as the one used to install the current database schema. In other words, if you upgraded the source code to a newer v13 release after installation, the source code and database schema may be out of sync and you **cannot** safely use the command below. If that is your situation, please ask for help on our Discord server.
+
+On the server, run the following command to create the `alembic_version` table:
+
+```bash
+pipenv run invenio alembic stamp
+```
+
+Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
+
+## Switch from pipenv to uv — optional but recommended
 
 Although not strictly necessary for this upgrade, we highly encourage you to switch to [uv](https://docs.astral.sh/uv/) from [pipenv](https://pipenv.pypa.io/) for your Python package and project manager, for improvements in speed, ergonomics, and [security](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns). Future releases will only document steps using `uv` commands and may remove support for `pipenv`.
 
@@ -247,13 +269,40 @@ This step ensures that all subsequent commands use the correct Python environmen
 
 ### Apply database migrations
 
-Execute the database migrations to update table schemas:
+The database migration consists of two steps: a pre-migration step that cleans up the existing database schema, followed by an Alembic upgrade to the v14 schema.
+
+#### Run the pre-migration step
+
+Run one of the following commands, depending on whether your installation uses `uv` or `pipenv`:
+
+```bash
+# if using uv
+invenio shell $(find $(dirname $(dirname $(uv python find)))/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
+# if using pipenv
+invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name prepare_migration_13_0_to_14_0.py)
+```
+
+If the script completes successfully, it should end with output similar to the following:
+
+```
+...
+
+    v13 -> v14 database cleanup completed successfully.
+
+    Please run:
+
+        invenio alembic upgrade
+
+    to finish the database structure migration process. Then continue with the data migration script.
+```
+
+#### Run the schema migration step
+
+Once the pre-migration step has completed successfully, run the Alembic migration to update the database schema:
 
 ```bash
 invenio alembic upgrade
 ```
-
-TODO: Fill with more advanced migration command of this version that fixes migration histories
 
 ### Apply data changes
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -38,38 +38,50 @@ With the end-of-life of Python 3.9 in October 2025, InvenioRDM v14 recommends us
 
 1.  Install Python 3.14 so it can be used by your application (including in new [virtualenv](../../reference/virtualenvs.md) created by invenio-cli). We only list two methods here — the internet is rife with other examples.
 
-    ```bash
-    # with uv
-    uv python install 3.14
-    # OR with the pyenv tool (https://github.com/pyenv/pyenv)
-    pyenv install 3.14
-    ```
+
+    === "uv"
+
+        ```bash
+        uv python install 3.14
+        ```
+
+    === "pyenv"
+
+        ```bash
+        # With the pyenv tool (https://github.com/pyenv/pyenv)
+        pyenv install 3.14
+        ```
 
 2.  Change the required Python version in `pyproject.toml` if using `uv` or `Pipfile` if still using `pipenv`.
 
-    **pyproject.toml**
+    === "pyproject.toml"
 
-    ```toml
-    # Set this line
-    requires-python = "~=3.14.0"
-    ```
+        ```toml
+        # Set this line
+        requires-python = "~=3.14.0"
+        ```
 
-    **Pipfile**
+    === "Pipfile"
 
-    ```ini
-    [requires]
-    # Set this line
-    python_version = "3.14"
-    ```
+        ```ini
+        [requires]
+        # Set this line
+        python_version = "3.14"
+        ```
 
 3.  Regenerate the lock file
 
-    ```bash
-    # with uv
-    uv lock --refresh
-    # with pipenv
-    pipenv lock
-    ```
+    === "uv"
+
+        ```bash
+        uv lock --refresh
+        ```
+
+    === "pipenv"
+
+        ```bash
+        pipenv lock
+        ```
 
     You will then want to use a new virtualenv like [detailed below](#upgrade-option-2-new-virtual-environment). At this point you may want to re-install the v13 packages in this new environment just to make sure your instance is compatible with Python 3.14 and resolve any issues specific to that if any. Keep in mind that InvenioRDM v14 may resolve some too.
 
@@ -184,19 +196,22 @@ option you choose.
 
 Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` or `<my-site>/Pipfile`:
 
-**Pipfile**
-```diff
-[packages]
----invenio-app-rdm = {extras = [...], version = "~=13.0.0"}
-+++invenio-app-rdm = {extras = [...], version = "~=14.0.0"}
-```
+=== "pyproject.toml"
 
-**pyproject.toml**
-```diff
-dependencies = [
----    invenio-app-rdm[opensearch2]~=13.0.0",
-+++    invenio-app-rdm[opensearch2]~=14.0.0",
-```
+    ```diff
+    dependencies = [
+    ---    invenio-app-rdm[opensearch2]~=13.0.0",
+    +++    invenio-app-rdm[opensearch2]~=14.0.0",
+    ```
+
+=== "Pipfile"
+
+    ```diff
+    [packages]
+    ---invenio-app-rdm = {extras = [...], version = "~=13.0.0"}
+    +++invenio-app-rdm = {extras = [...], version = "~=14.0.0"}
+    ```
+
 
 ##### Step 3
 
@@ -244,12 +259,17 @@ TODO: Fill with more advanced migration command of this version that fixes migra
 
 Execute the data migration script to update the content of the DB:
 
-```bash
-# if using uv
-invenio shell $(find $(dirname $(dirname $(uv python find)))/lib/*/site-packages/invenio_app_rdm -name migrate_13_to_14.py)
-# if using pipenv
-invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name migrate_13_to_14.py)
-```
+=== "uv"
+
+    ```bash
+    invenio shell $(find $(dirname $(dirname $(uv python find)))/lib/*/site-packages/invenio_app_rdm -name migrate_13_0_to_14_0.py)
+    ```
+
+=== "pipenv"
+
+    ```bash
+    invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name migrate_13_0_to_14_0.py)
+    ```
 
 #### OAuth client changes
 
@@ -268,7 +288,9 @@ Many mappings have been updated in this release. You can perform granular change
 TODO: Check if it is indeed the case that the discard and rebuild is enough
 
 **Discard and rebuild indices**
+
 ```bash
+# precede by uv run or pipenv run as appropriate
 invenio index destroy --yes-i-know
 invenio index init
 # if you have records custom fields

--- a/docs/releases/v14/version-v14.0.md
+++ b/docs/releases/v14/version-v14.0.md
@@ -213,7 +213,7 @@ Here is a quick summary of the other improvements in this release:
 - Temporarily pinned `bcrypt<5.0.0` due to compatibility issues ([flask-security-fork#82](https://github.com/inveniosoftware/flask-security-fork/pull/82)). Will be lifted in a future release.
 - A new configuration variable, `RDM_RECORDS_RELATED_IDENTIFIERS_SCHEMES`, enables configuring identifier schemes specifically for related identifiers, defaulting to `RDM_RECORDS_IDENTIFIERS_SCHEMES` when not defined.
 - Deposit form: "Creators" label was changed to "Authors" to clarify that they appear in citations.
-- Resource types: the default vocabulary now labels `publication-dissertation` as "Thesis" and drops the separate `publication-thesis` entry, so DataCite DOIs use the standard `Dissertation` value instead of a custom `Text` one. Migrating your existing records to this change is entirely optional; see [aligning the "Thesis" and "Dissertation" resource types](./upgrade-v14.0.md#align-thesis-and-dissertation-resource-types-optional) in the upgrade guide.
+- Resource types: the default vocabulary now labels `publication-dissertation` as "Thesis" and drops the separate `publication-thesis` entry, so DataCite DOIs use the standard `Dissertation` value instead of a custom `Text` one. Migrating your existing records to this change is entirely optional; see [aligning the "Thesis" and "Dissertation" resource types](./upgrade-v14.0.md#align-thesis-and-dissertation-resource-types) in the upgrade guide.
 - A new configuration variable, `RDM_RECORDS_REQUIRE_SECRET_LINKS_EXPIRATION`, controls whether an expiration date must be set for access links and secret links. Defaults to `FALSE` when not defined.
 - Addition of support for Wikidata identifiers (QIDs) for creators and contributors of records and their affiliations.
 - Addition of an HTTP User-Agent helper (`invenio_user_agent`) for outbound HTTP requests in `invenio-vocabularies` datastreams.
@@ -232,9 +232,10 @@ Here is a quick summary of the other improvements in this release:
 ## Breaking changes
 
 - Overridables in the deposit form have been modified to improve consistency in structure and naming conventions. This has involved renaming the IDs of several `<Overridable>`s, but none have been removed. If you are using these IDs to override components, please see [the full list of updates](https://github.com/inveniosoftware/invenio-rdm-records/pull/2101/files#diff-ff3c479edefad986d2fe6fe7ead575a46b086e3bbcf0ccc86d85efc4a4c63c79) and change your IDs accordingly.
-- The changes to [invenio-oauthclient](https://github.com/inveniosoftware/invenio-oauthclient) include automated database migrations that will run smoothly for most instances. However, if your `oauthclient_remoteaccount` table has more than ~50k rows and you are unable to take your system offline for the upgrade, please instead [follow the manual steps](./upgrade-v14.0.md#oauth-client-changes).
 - The default value for `WSGI_PROXIES` has been removed from Invenio-App-RDM in [PR 3284](https://github.com/inveniosoftware/invenio-app-rdm/pull/3284); instead `PROXYFIX_CONFIG` should be configured (cf. the [cookiecutter](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/blob/83bb37436980ab8998a80fa0429e7d09f01f45f2/%7B%7Bcookiecutter.project_shortname%7D%7D/docker-services.yml#L24))
 - The configuration variable to display the Browse menu tab in communities has been renamed from `COMMUNITIES_SHOW_BROWSE_MENU_ENTRY` to `COMMUNITIES_COLLECTIONS_ENABLED`. Check if the former was declared in your `invenio.cfg`.
+- Per [v13 deprecation notice](../v13/version-v13.0.0.md#deprecations), usage of `invenio_records_resources.services.Link` has been replaced by `invenio_records_resources.services.EndpointLink` for InvenioRDM links and `invenio_records_resources.services.ExternalLink` for external third-party links. Continued import of `Link` is incorrect (may still work, but is being removed completely).
+
 
 ## Requirements
 
@@ -281,7 +282,6 @@ The development of this release wouldn't have been possible without the help of 
 - jakob miesner
 - Javier Romero Castro
 - Jorge Marco
-- jrcastro2
 - Julie Hinge
 - Karl Krägelin
 - Karolina Przerwa
@@ -318,7 +318,6 @@ The development of this release wouldn't have been possible without the help of 
 - Till Korten
 - Tom Morrell
 - Uma Ganapathy
-- utnapischtim
 - Werner Greßhoff
 - yashlamba
 - Zacharias Zacharodimos


### PR DESCRIPTION
- **v14: document proper setup of WEBPACKEXT_NPM_PKG_CLS**
- **v14: make uv default across the board (with pipenv as alternative)**
- **feat: v14 pre-migration script added to docs**
- **chore(v14/upgrade): remove online migration**
- **v14: combine + clean upgrade notes from #970 and #968**
