### PR TITLE
Move the `alembic_version` step before the package upgrade step

### DIFF
--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -324,6 +324,44 @@ Once the pre-migration step has completed successfully, run the Alembic migratio
 invenio alembic upgrade
 ```
 
+!!! info "Unique constraint violation errors can be solved with database cleanups"
+
+    In some rare cases, instances have been observed to run into *unique constraint violations* (e.g. `sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) ...`) during the Alembic upgrade.
+    This can happen due to leftover artifacts that were never properly cleaned up, likely due to old bugs.
+    Removing the offending leftover rows from the database will resolve these errors.
+
+    The necessary steps depend on the concrete situation, but generally what's needed in such cases is to clean up the tables mentioned in the error message.
+    For example, the following error would tell you that you need to delete old entries from the `rdm_records_files` table, and which `(record_id, key)` combination to look out for.
+
+    ---
+
+    The following is a real-life example with altered identifiers:
+    ```
+    sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) could not create unique index "uidx_rdm_records_files_record_id_key"
+    DETAIL:  Key (record_id, key)=(0e49c6bb-6772-4b13-ab7f-87fd3fca18ed, research_NMR.zip) is duplicated.
+
+    [SQL: CREATE UNIQUE INDEX IF NOT EXISTS uidx_rdm_records_files_record_id_key ON rdm_records_files (record_id, key)]
+    ```
+
+    In this example, we can see that there are two entries for the reported `record_id`, and the older one has has its `object_version_id` set to `null`:
+    ```
+    inveniordm=> SELECT * FROM rdm_records_files WHERE record_id = '0e49c6bb-6772-4b13-ab7f-87fd3fca18ed';
+              created           |          updated           |                  id                  | json | version_id |       key        |              record_id               |          object_version_id
+    ----------------------------+----------------------------+--------------------------------------+------+------------+------------------+--------------------------------------+--------------------------------------
+     2024-12-03 18:09:12.125274 | 2024-12-03 18:09:12.125283 | 20a5a54a-5c6a-400d-aa3e-5db99323768c | {}   |          1 | research_NMR.zip | 0e49c6bb-6772-4b13-ab7f-87fd3fca18ed |
+     2024-12-03 18:09:33.503182 | 2024-12-03 18:09:33.546971 | 17235935-1e95-4529-b189-82a250113e93 | {}   |          3 | research_NMR.zip | 0e49c6bb-6772-4b13-ab7f-87fd3fca18ed | 2e218ef5-ba92-4fa4-a58a-0c204fc771a1
+    (2 rows)
+    ```
+
+    It could be resolved with `DELETE FROM rdm_records_files WHERE record_id = '0e49c6bb-6772-4b13-ab7f-87fd3fca18ed' AND object_version_id IS null`.
+
+    After that cleanup, `invenio alembic upgrade` went through successfully.
+
+    ---
+
+    ⚠️ Be careful to only clean up the *leftover data*, though!
+    If you are unsure which entries *are* the leftovers, feel free to ask for help in the Discord server.
+
 ### Apply data changes
 
 Execute the data migration script to update the content of the DB:

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -177,6 +177,44 @@ Here are the core sequential steps to upgrade to InvenioRDM v14.
 
     All commands below assume you are running them according to their installation environments. Typically it means `invenio` commands should be executed inside the application's virtual environment or via `pipenv run` or `uv run` in case you are not inside a virtual environment or environment with executables installed globally.
 
+### Check your database for the `alembic_version` table
+
+InvenioRDM v13 contained a race condition that, in some cases, prevented the `alembic_version` table from being created in the database. [Alembic](https://alembic.sqlalchemy.org/) uses this table to track database schema migrations, and you cannot upgrade to v14 without it.
+
+!!! warning "Check the `alembic_version` table before updating any packages!"
+
+    It's important that this step is performed with the v13 packages still installed!
+    If you run `invenio alembic stamp` after upgrading to the v14 packages, the `alembic_version` entries will be incorrect.
+
+To check whether your database has the `alembic_version` table, log in to the database and run the following SQL query:
+
+```sql
+SELECT * FROM alembic_version;
+```
+
+**If the table exists and contains rows, then you're fine; skip the rest of this step and continue with the next ([Upgrade invenio-cli](#upgrade-invenio-cli)).**
+
+If you get `ERROR: relation "alembic_version" does not exist`, the table is missing and you must create it before proceeding.
+If the table exists but has no entries, it has to be populated in the same way.
+
+To create the table and/or populate it, you need to run the command on the InvenioRDM server. The server **must** be using the same source code version as the one used to install the current database schema. In other words, if you upgraded the source code to a newer v13 release after installation, the source code and database schema may be out of sync and you **cannot** safely use the command below. If that is your situation, please ask for help on our Discord server.
+
+On the server, run the following command to create the `alembic_version` table:
+
+=== "uv"
+
+    ```bash
+    uv run invenio alembic stamp
+    ```
+
+=== "pipenv"
+
+    ```bash
+    pipenv run invenio alembic stamp
+    ```
+
+Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
+
 ### Upgrade invenio-cli
 
 Make sure you have the latest `invenio-cli` installed. For InvenioRDM v14,
@@ -244,39 +282,9 @@ invenio-cli install
 
 The database migration consists of three steps:
 
-- check about existing `alembic_version` table
+- check about existing `alembic_version` table (this is described in the section [Check your database for the `alembic_version` table](#check-your-database-for-the-alembic_version-table) above)
 - pre-migration step that cleans up the existing database schema
 - Alembic upgrade to the v14 schema
-
-#### Check your database for the `alembic_version` table
-
-InvenioRDM v13 contained a race condition that, in some cases, prevented the `alembic_version` table from being created in the database. [Alembic](https://alembic.sqlalchemy.org/) uses this table to track database schema migrations, and you cannot upgrade to v14 without it.
-
-To check whether your database has the `alembic_version` table, log in to the database and run the following SQL query:
-
-```sql
-SELECT * FROM alembic_version;
-```
-
-If you get `ERROR: relation "alembic_version" does not exist`, the table is missing and you must create it before proceeding.
-
-To create the table, you need to run the command on the InvenioRDM server. The server **must** be using the same source code version as the one used to install the current database schema. In other words, if you upgraded the source code to a newer v13 release after installation, the source code and database schema may be out of sync and you **cannot** safely use the command below. If that is your situation, please ask for help on our Discord server.
-
-On the server, run the following command to create the `alembic_version` table:
-
-=== "uv"
-
-    ```bash
-    uv run invenio alembic stamp
-    ```
-
-=== "pipenv"
-
-    ```bash
-    pipenv run invenio alembic stamp
-    ```
-
-Afterwards, check the `alembic_version` table again to confirm that the operation completed successfully.
 
 #### Run the pre-migration step
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -278,13 +278,14 @@ invenio-cli install
     As such we don't mention this option anymore.
 
 
-### Apply database migrations
+### Update database schemas and content
 
 The database migration consists of three steps:
 
-- check about existing `alembic_version` table (this is described in the section [Check your database for the `alembic_version` table](#check-your-database-for-the-alembic_version-table) above)
-- pre-migration step that cleans up the existing database schema
-- Alembic upgrade to the v14 schema
+- a check for an existing `alembic_version` table. This is described in the section [Check your database for the `alembic_version` table](#check-your-database-for-the-alembic_version-table) above and should have already been done.
+- a pre-migration step that cleans up the existing database schema
+- a v14 migration of the database schemas
+- a v14 migration of the database content
 
 #### Run the pre-migration step
 
@@ -343,7 +344,7 @@ invenio alembic upgrade
     [SQL: CREATE UNIQUE INDEX IF NOT EXISTS uidx_rdm_records_files_record_id_key ON rdm_records_files (record_id, key)]
     ```
 
-    In this example, we can see that there are two entries for the reported `record_id`, and the older one has has its `object_version_id` set to `null`:
+    In this example, we can see that there are two entries for the reported `record_id`, and the older one has had its `object_version_id` set to `null`:
     ```
     inveniordm=> SELECT * FROM rdm_records_files WHERE record_id = '0e49c6bb-6772-4b13-ab7f-87fd3fca18ed';
               created           |          updated           |                  id                  | json | version_id |       key        |              record_id               |          object_version_id
@@ -362,7 +363,7 @@ invenio alembic upgrade
     ⚠️ Be careful to only clean up the *leftover data*, though!
     If you are unsure which entries *are* the leftovers, feel free to ask for help in the Discord server.
 
-### Apply data changes
+#### Run the content migration
 
 Execute the data migration script to update the content of the DB:
 


### PR DESCRIPTION
Executing the `invenio alembic stamp` command *after* upgrading the packages to v14 would result in incorrect version stamps for sure, so it's important that this step is performed with the old packages installed.
Also, clarify the condition under which this step can be skipped.

<img width="694" height="1451" alt="image" src="https://github.com/user-attachments/assets/46da97d3-e419-4098-8aae-2703aecad00c" />
