### PR TITLE
Simplify loading of the thesis-to-dissertation migration script

### DIFF
--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -546,11 +546,7 @@ Both rely on the [`migrate_thesis_to_dissertation.py`](./migrate_thesis_to_disse
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/inveniosoftware/docs-invenio-rdm/master/docs/releases/v14/migrate_thesis_to_dissertation.py -o /tmp/migrate_thesis_to_dissertation.py
-```
-
-```python
-# in `invenio shell`
-exec(open("/tmp/migrate_thesis_to_dissertation.py").read())
+invenio shell -i -- /tmp/migrate_thesis_to_dissertation.py
 ```
 
 Always test against a copy of your data first.


### PR DESCRIPTION
Both `python` and `ipython` (which is used by `flask shell` and `invenio shell` if available) support the `-i` flag, we could use that to look a bit less like hackers.

Or is there a scenario where this might not be available, and going with `exec()` is safer?