### PR TITLE
fix: correct indentation for info box

### DIFF
--- a/docs/operate/customize/file-modification.md
+++ b/docs/operate/customize/file-modification.md
@@ -59,7 +59,7 @@ The second time period of 45 days exists to prevent users from repeatedly editin
 
 !!! info
 
-  Short time periods are recommended for the file modification period as there is a risk of submitters treating records as file storage, and not respecting that a DOI has been minted for this digital object.
+    Short time periods are recommended for the file modification period as there is a risk of submitters treating records as file storage, and not respecting that a DOI has been minted for this digital object.
 
 ## Configure out of policy messages
 

--- a/docs/operate/customize/file-uploads/zip-and-container-files.md
+++ b/docs/operate/customize/file-uploads/zip-and-container-files.md
@@ -119,6 +119,7 @@ Support for additional container formats can be added by implementing the `FileE
 [architecture documentation](../../../maintenance/architecture/records.md#container-files) for details.
 
 Future container formats under consideration include:
+
 - **NetCDF**: For multidimensional scientific data with logical sections
 - **TAR/TAR.GZ**: For general-purpose archive support
 - **WACZ/WARC**: For web archives (already supported via a separate previewer)

--- a/docs/operate/customize/record_deletion.md
+++ b/docs/operate/customize/record_deletion.md
@@ -56,6 +56,7 @@ If your criteria depend on resource type, community membership, or other factors
 ## Configure modal checklists
 
 The deletion modal can present a checklist to guide users toward alternatives to deleting a record. For example, deletion is usually unnecessary in these situations:
+
 - The user forgot to submit the record to a community before publishing — the record can be added to the community afterwards.
 - The user wants to replace a file — files can be replaced by the user after publication (if allowed) or by administrators.
 - The user wants to change the DOI — the DOI can be updated by editing the record (if allowed).


### PR DESCRIPTION
Before:
<img width="936" height="386" alt="image" src="https://github.com/user-attachments/assets/f5adfbb6-b637-439f-9244-ff77fa928d19" />

After:
<img width="967" height="343" alt="image" src="https://github.com/user-attachments/assets/c732b961-5c52-495b-8eb8-33184f5e544d" />

---

Before:
<img width="895" height="373" alt="image" src="https://github.com/user-attachments/assets/b296de4d-efcd-4862-b335-1618c7af4c9f" />

After:
<img width="900" height="460" alt="image" src="https://github.com/user-attachments/assets/8be684fd-d335-42d7-899b-60e1fcdb5c72" />

---

Before:
<img width="996" height="419" alt="image" src="https://github.com/user-attachments/assets/2af9fa83-167d-4da9-ad29-e09ba5d61f68" />

After:
<img width="1239" height="525" alt="image" src="https://github.com/user-attachments/assets/c6fcd63f-7abf-442b-8746-aa27022b80a7" />