### PR TITLE
v14: mention that `invenio-checks` was decoupled from communities

### DIFF
--- a/docs/releases/v14/version-v14.0.md
+++ b/docs/releases/v14/version-v14.0.md
@@ -231,6 +231,7 @@ Here is a summary of other improvements in this release:
 - Added **cache-control headers** for both local and S3-served files. This is necessary for repositories that use a proxy service such as Cloudflare in front of InvenioRDM.
 - Added an HTTP User-Agent helper (**`invenio_user_agent`**) for outbound HTTP requests in `invenio-vocabularies` datastreams to identify requests performed by InvenioRDM.
 - Reproducible Javascript builds are finally possible. See [**Build and Lock Assets**](../../operate/ops/deploy.md#inveniordm-application).
+- Decoupled `invenio-checks` from `invenio-communities`. [Checks](../../operate/customize/curation-checks.md) can now be used with any request type!
 - Plenty of bug fixes as usual!
 
 ## Deprecations


### PR DESCRIPTION
This is something delightful for those that are using `Invenio-Curations`!

Proof of concept very quickly hacked together (just checked if it works, don't want to spread lies in the docs):
<img width="1687" height="947" alt="image" src="https://github.com/user-attachments/assets/69089bc1-2073-49c0-bf02-d7f1b516d258" />
<img width="1734" height="521" alt="image" src="https://github.com/user-attachments/assets/8c6b2f36-3db6-49f6-b7a7-1f3f14e400f7" />
