### PR TITLE
fix(migration): recreate percolator index for the new mapping

### DIFF
--- a/docs/releases/v14/migrate_percolator_and_jobs_datastream.py
+++ b/docs/releases/v14/migrate_percolator_and_jobs_datastream.py
@@ -4,12 +4,14 @@
 
 """OAI-PMH and Jobs Datastream migrator from InvenioRDM 13.0 to 14.0."""
 
+import json
+
 from click import secho
 from flask import current_app
 from invenio_access.permissions import system_identity
 from invenio_oaiserver.percolator import _build_percolator_index_name
 from invenio_rdm_records.proxies import current_rdm_records
-from invenio_search.proxies import current_search_client
+from invenio_search.proxies import current_search, current_search_client
 from invenio_search.utils import build_alias_name
 from opensearchpy.exceptions import RequestError
 
@@ -23,13 +25,16 @@ def update_oai_pmh_percolator():
     # Fetch the mapping from the "live" index (this will include custom fields)
     record_mapping = current_search_client.indices.get_mapping(index=record_index)
     assert len(record_mapping) == 1
-    percolator_mappings = list(record_mapping.values())[0]["mappings"]
+    mappings = list(record_mapping.values())[0]["mappings"]
+    mappings["properties"]["query"] = {"type": "percolator"}
+    with open(current_search.mappings[index]) as fp:
+        settings = json.load(fp)["settings"]
+    percolator_body = {"settings": settings, "mappings": mappings}
 
-    # Update the mapping
-    current_search_client.indices.put_mapping(
-        index=percolator_index,
-        body=percolator_mappings,
-    )
+    # Recreate the percolator index, to avoid mapping conflicts
+    assert percolator_index != record_index
+    current_search_client.indices.delete(index=percolator_index)
+    current_search_client.indices.create(index=percolator_index, body=percolator_body)
 
     # Reindex all percolator queries from OAISets
     oaipmh_service = current_rdm_records.oaipmh_server_service


### PR DESCRIPTION
The old percolator index still has the v13 record mapping, so applying the
v14 one on top of it fails for any field whose type changed. It's deleted
and created again from the record index settings and mapping instead. The
queries in it are restored by the OAI-PMH reindex right after.
