### PR TITLE
v14 final touches

### DIFF
--- a/docs/releases/v14/switch-to-pnpm.md
+++ b/docs/releases/v14/switch-to-pnpm.md
@@ -4,8 +4,7 @@
 Javascript dependencies in InvenioRDM (don't worry npm still works)
 because it is much faster, [has better protection against supply chain
 attacks](https://pnpm.io/supply-chain-security), and has good
-community support. If you have it installed, `invenio-cli` and lower
-level `invenio` commands will use it under the hood (if installed).
+community support.
 
 1.  Locally, install [pnpm](https://pnpm.io/installation) version 11 (working version at time of writing).
 
@@ -13,11 +12,9 @@ level `invenio` commands will use it under the hood (if installed).
 
     ```ini
     [cli]
-    # set this line or remove it altogether
+    # set this line
     javascript_package_manager = pnpm
     ```
-
-    You could remove the line altogether since pnpm is the new default if that line is not present.
 
 3.  In your `invenio.cfg`, set:
 

--- a/docs/releases/v14/switch-to-uv.md
+++ b/docs/releases/v14/switch-to-uv.md
@@ -56,7 +56,7 @@ To run the script follow these steps:
 cd my-site/
 
 # Download the script in a temporary location
-curl -LsSf https://raw.githubusercontent.com/inveniosoftware/docs-invenio-rdm/main/docs/releases/uv_migrate.py -o /tmp/uv_migrate.py
+curl -LsSf https://raw.githubusercontent.com/inveniosoftware/docs-invenio-rdm/master/docs/releases/v14/uv_migrate.py -o /tmp/uv_migrate.py
 
 # Adjust "TARGET_PYTHON_VERSION" in the script to your desired Python version
 

--- a/docs/releases/v14/switch-to-uv.md
+++ b/docs/releases/v14/switch-to-uv.md
@@ -120,7 +120,7 @@ members = ["site"]
 
 [dependency-groups] # (7)!
 dev = [
-    "pytest-invenio>=3.0.0,<4.0.0",
+    "pytest-invenio>=4.0.0,<5.0.0", # (8)!
     # ... other dev dependencies
 ]
 ```
@@ -132,6 +132,7 @@ dev = [
 5. Defines where uv should find local packages (including workspace members)
 6. Declares this is a workspace project with "site" as a member package
 7. Replaces Pipfile's `[dev-packages]` - groups dependencies by their purpose
+8. v14 needs `pytest-invenio` 4.x. The script bumps the pin it copies from `site/setup.cfg`.
 
 ??? info "Understanding uv Workspaces"
 
@@ -154,7 +155,7 @@ name = my-site
 
 [options.extras_require]
 tests =
-    pytest-invenio>=3.0.0,<4.0.0
+    pytest-invenio>=2.1.0,<3.0.0
     # ...other test dependencies
 
 [options.entry_points]

--- a/docs/releases/v14/switch-to-uv.md
+++ b/docs/releases/v14/switch-to-uv.md
@@ -220,8 +220,8 @@ The script writes a `.python-version` file so everyone working on the instance a
 Remove any old files, including a stale `*.egg-info` directory under `site/` (a leftover from the old setuptools build can shadow your new entry points):
 
 ```bash
-rm Pipfile Pipfile.lock site/setup.cfg site/setup.py site/MANIFEST.in
-rm -rf site/*.egg-info
+rm -f Pipfile Pipfile.lock site/setup.cfg site/setup.py site/MANIFEST.in
+find site -maxdepth 1 -name '*.egg-info' -exec rm -rf {} +
 ```
 
 ### Update Dockerfile

--- a/docs/releases/v14/switch-to-uv.md
+++ b/docs/releases/v14/switch-to-uv.md
@@ -39,7 +39,7 @@ by a 📜 icon:
 - "Clean up old files"
 
 The script assumes a "standard" InvenioRDM bootstrapped project structure (e.g. it reads
-from the `.invenio` file to auto-detect the project name, Python version, and author
+from the `.invenio` file to auto-detect the project name and author
 info), so you may come across issues if your project structure and configuration has
 deviated significantly. In any case, the script is just a starting point, and you will
 still need to manually verify and adjust the following:
@@ -57,8 +57,6 @@ cd my-site/
 
 # Download the script in a temporary location
 curl -LsSf https://raw.githubusercontent.com/inveniosoftware/docs-invenio-rdm/master/docs/releases/v14/uv_migrate.py -o /tmp/uv_migrate.py
-
-# Adjust "TARGET_PYTHON_VERSION" in the script to your desired Python version
 
 # Run the script using uv
 uv run /tmp/uv_migrate.py
@@ -104,8 +102,7 @@ name = "my-site-app" # (1)!
 version = "1.0.0" # (2)!
 authors = [{ name = "My Organization" }] # (3)!
 license = "MIT"
-requires-python = ">=3.14"  # the value defined by TARGET_PYTHON_VERSION in the
-                            # uv_migrate.py script
+requires-python = "~=3.14.0"
 dependencies = [
     "invenio-app-rdm[opensearch2]~=13.0.0",
     "my-site", # (4)!
@@ -212,7 +209,7 @@ project_name = My Site
 The script writes a `.python-version` file so everyone working on the instance and your CI resolve to the same interpreter. It holds a single line:
 
 ```text title=".python-version"
-3.14 # the value defined by TARGET_PYTHON_VERSION in the uv_migrate.py script
+3.14
 ```
 
 ### Clean up old files 📜

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -146,9 +146,21 @@ Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` if
 ### Install InvenioRDM v14:
 
 
-```bash
-invenio-cli install
-```
+=== "uv"
+
+    ```bash
+    invenio-cli install
+    ```
+
+=== "pipenv"
+
+    `invenio-cli install` reuses the existing virtualenv and `Pipfile.lock`, so recreate both:
+
+    ```bash
+    pipenv --rm
+    invenio-cli packages lock
+    invenio-cli install
+    ```
 
 ### Update database schemas and content
 
@@ -269,7 +281,6 @@ invenio rdm-records add-to-fixture removalreasons
     The `resourcetypes` vocabulary was also subject to another cleanup operation upstream that removed an entry from it.
     The commands above only add or update entries. Steps to follow to replicate this removal in your instance can be
     found in the [section about aligning "thesis" and "dissertation" resource types](#align-thesis-and-dissertation-resource-types) below.
-
 
 ## Update your configuration or infrastructure
 

--- a/docs/releases/v14/upgrade-v14.0.md
+++ b/docs/releases/v14/upgrade-v14.0.md
@@ -131,16 +131,16 @@ Change the version of `invenio-app-rdm` to 14.0 in `<my-site>/pyproject.toml` if
 
     ```diff
     dependencies = [
-    ---    invenio-app-rdm[opensearch2]~=13.0.0",
-    +++    invenio-app-rdm[opensearch2]~=14.0.0",
+    -    "invenio-app-rdm[opensearch2]~=13.0.0",
+    +    "invenio-app-rdm[opensearch2]~=14.0.0",
     ```
 
 === "Pipfile"
 
     ```diff
     [packages]
-    ---invenio-app-rdm = {extras = [...], version = "~=13.0.0"}
-    +++invenio-app-rdm = {extras = [...], version = "~=14.0.0"}
+    -invenio-app-rdm = {extras = [opensearch2], version = "~=13.0.0"}
+    +invenio-app-rdm = {extras = [opensearch2], version = "~=14.0.0"}
     ```
 
 ### Install InvenioRDM v14:
@@ -229,10 +229,9 @@ invenio rdm rebuild-all-indices
 #### Update OAI-PMH percolator mapping and Job Logs Index
 
 
-Percolators and job datastreams need the `invenio index init` step to
-get the new mapping and the new mapping but are not affected by index
-rebuild from the step before. They have to be updated by running the
-following script.
+Percolators and job datastreams get their new mapping from the `invenio
+index init` step, but are not affected by the index rebuild from the step
+before. They have to be updated by running the following script.
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/inveniosoftware/docs-invenio-rdm/master/docs/releases/v14/migrate_percolator_and_jobs_datastream.py -o /tmp/migrate_percolator_and_jobs_datastream.py
@@ -260,7 +259,7 @@ In order to update these in your repository, you'll need for each vocabulary to:
 
 2.  If you've customized the vocabulary for your instance, you will need to merge changes from the [source files in invenio-rdm-records](https://github.com/inveniosoftware/invenio-rdm-records/tree/master/invenio_rdm_records/fixtures/data/vocabularies) into the custom vocabulary file in your instance according to what you and/or your stakeholders think makes sense in your context. If you have not customized the vocabulary, you are probably fine with adopting the changes, but you can always double-check what those are and decide if you adopt them.
 
-3.  If you've decided to adopt the changes (and have merged the changes per step 2.), run the vocabulary update command: `invenio rdm-records add-to-fixture <vocabulary fixture>`. For example: `invenio rdm-records add-to-fixture datetypes`/
+3.  If you've decided to adopt the changes (and have merged the changes per step 2.), run the vocabulary update command: `invenio rdm-records add-to-fixture <vocabulary fixture>`. For example: `invenio rdm-records add-to-fixture datetypes`.
 
 If you plan on adopting all those, you can run all the `add-to-fixture` commands:
 

--- a/docs/releases/v14/uv_migrate.py
+++ b/docs/releases/v14/uv_migrate.py
@@ -591,12 +591,7 @@ def cleanup_old_files(root_dir: Path) -> None:
     "--project-name",
     help="Name for the project (auto-detected from '.invenio' project_shortname if not provided)",
 )
-@click.option(
-    "--cleanup",
-    is_flag=True,
-    help="Remove old files (Pipfile, setup.cfg, etc.) after migration",
-)
-def main(root_dir: Path, project_name: Optional[str], cleanup: bool):
+def main(root_dir: Path, project_name: Optional[str]):
     """Migrate from Pipenv to uv."""
     site_dir = root_dir / "site"
 
@@ -703,15 +698,7 @@ def main(root_dir: Path, project_name: Optional[str], cleanup: bool):
         update_invenio_config(project_config)
         write_python_version(root_dir, python_version)
 
-        if cleanup:
-            cleanup_old_files(root_dir)
-        else:
-            click.secho(
-                "ℹ️ Old files (Pipfile, setup.cfg, etc.) were not removed", fg="yellow"
-            )
-            click.secho(
-                "   Run again with --cleanup to remove them after testing", fg="yellow"
-            )
+        cleanup_old_files(root_dir)
 
         click.secho("\n✅ Migration completed successfully!", fg="green", bold=True)
         click.secho("\nNext steps:", fg="cyan", bold=True)

--- a/docs/releases/v14/uv_migrate.py
+++ b/docs/releases/v14/uv_migrate.py
@@ -30,6 +30,11 @@ import tomllib
 # explicitly rather than carrying over the version from the v13 Pipfile.
 TARGET_PYTHON_VERSION = "3.14"
 
+# The v13 `tests` extra pins pytest-invenio 2.x, which pulls a pytest that does not run on
+# Python 3.14. uv installs the dev group by default, so carrying the old pin over breaks the
+# test suite of every migrated instance.
+TARGET_PYTEST_INVENIO = "pytest-invenio>=4.0.0,<5.0.0"
+
 
 @dataclass
 class ProjectConfig:
@@ -354,6 +359,23 @@ def convert_pipfile_to_pyproject(config: ProjectConfig) -> str:
         dev_dependencies = [
             dep for dep in dev_dependencies if not dep.startswith("check-manifest")
         ]
+        for i, dep in enumerate(dev_dependencies):
+            if (
+                dep.split("[")[0]
+                .split("=")[0]
+                .split("<")[0]
+                .split(">")[0]
+                .split("!")[0]
+                .split("~")[0]
+                .strip()
+                == "pytest-invenio"
+                and dep != TARGET_PYTEST_INVENIO
+            ):
+                click.secho(
+                    f"  ℹ️ Bumped '{dep}' to '{TARGET_PYTEST_INVENIO}' (required by InvenioRDM v14)",
+                    fg="blue",
+                )
+                dev_dependencies[i] = TARGET_PYTEST_INVENIO
 
     pyproject_data = {
         "project": {

--- a/docs/releases/v14/uv_migrate.py
+++ b/docs/releases/v14/uv_migrate.py
@@ -383,7 +383,7 @@ def convert_pipfile_to_pyproject(config: ProjectConfig) -> str:
             "version": "1.0.0",
             "authors": [{"name": config.author_name, "email": config.author_email}],
             "license": "MIT",
-            "requires-python": f">={TARGET_PYTHON_VERSION}",
+            "requires-python": f"~={TARGET_PYTHON_VERSION}.0",
             "dependencies": dependencies,
         }
     }


### PR DESCRIPTION
**fix(v14): bump the pytest-invenio pin carried over by uv_migrate.py**

* The v13 pin drags in a pytest that does not run on Python 3.14.

**fix(v14): correct the uv_migrate.py download path**

**fix(v14): re-lock and recreate the venv when upgrading with pipenv**

* Otherwise the Pipfile bump has no effect: invenio-cli only locks when no lock
  file exists, and pipenv sync installs from the stale one.

**fix(v14): correct the claims about pnpm being auto-detected**

* invenio-cli returns npm when the key is absent, and exports
  INVENIO_WEBPACKEXT_NPM_PKG_CLS, which overrides invenio.cfg.

**fix(v14): add a step to process the queued reindex and vocabulary tasks**

* Both report success once the tasks are queued, not once they run.

**fix(v14): fix the package diff blocks, percolator sentence and a stray slash**

**fix(v14): make the cleanup commands safe to re-run**

* v13 has no site/MANIFEST.in, and the egg-info glob aborts under zsh when
  nothing matches.

**fix(v14): always target Python 3.14 in the uv migration**

**fix(v14): remove the old files by default**

* The documented invocation never passed --cleanup, so the stale
  site/*.egg-info stayed behind and shadowed the new entry points.