### PR TITLE
fix(access-request): mention record manager

### DIFF
--- a/docs/use/records.md
+++ b/docs/use/records.md
@@ -121,7 +121,7 @@ As a user that would like to get access to restricted files of a record, it is n
 
 ### Accepting/Declining the request
 
-The submitter and the record's owner can find the newly created access request in "My dashboard" -> "Requests", and can exchange comments. The record's owner can define a new expiration date (changing the default settings) for this access request, accept or decline it:
+The submitter and the record's owner or manager can find the newly created access request in "My dashboard" -> "Requests", and can exchange comments. The record's owner or manager can define a new expiration date (changing the default settings) for this access request, accept or decline it:
 ![Access request request page guest](imgs/records/access_request_request_page_guest.png){: .screenshot}
 
 After accepting the request, the requester will receive a [notification](notifications.md) by e-mail and will be able to access the restricted files:


### PR DESCRIPTION
Since invenio-rdm-records#2401, record managers can also receive and handle access requests, so the documentation should reflect that.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've targeted the `master` branch.
- [x] If this documentation change impacts the current release of InvenioRDM, I will backport it to the `production` branch following approval or indicate to a maintainer that it should be backported.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
